### PR TITLE
Upgrade and pin `foundry_evm` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ num-bigint = "0.4"
 num-traits = "0.2"
 rand = "0.8"
 rand_chacha = "0.3.1"
-halo2_curves = { git = "https://github.com/privacy-scaling-explorations/halo2curves", tag = "v0.2.0", package = "halo2curves" }
+halo2_curves = { git = "https://github.com/privacy-scaling-explorations/halo2curves", tag = "0.2.1", package = "halo2curves" }
 
 # halo2
 blake2b_simd = { version = "1.0.0", optional = true }
@@ -25,7 +25,7 @@ poseidon = { git = "https://github.com/privacy-scaling-explorations/poseidon", b
 
 # evm
 ethereum_types = { package = "ethereum-types", version = "0.13.1", default-features = false, features = ["std"], optional = true }
-foundry_evm = { git = "https://github.com/foundry-rs/foundry", package = "foundry-evm", optional = true }
+foundry_evm = { git = "https://github.com/foundry-rs/foundry", package = "foundry-evm", rev = "93ee742d", optional = true }
 crossterm = { version = "0.22.1", optional = true }
 tui = { version = "0.16.0", default-features = false, features = ["crossterm"], optional = true }
 sha3 = { version = "0.10.1", optional = true }
@@ -43,13 +43,12 @@ sanity-check = []
 
 [patch.crates-io]
 halo2_proofs = { git = "https://github.com/han0110/halo2", branch = "experiment", package = "halo2_proofs" }
-revm = { git = "https://github.com/bluealloy/revm", package = "revm"  }
 
 [patch."https://github.com/privacy-scaling-explorations/halo2"]
 halo2_proofs = { git = "https://github.com/han0110/halo2", branch = "experiment", package = "halo2_proofs" }
 
 [patch."https://github.com/privacy-scaling-explorations/halo2curves"]
-halo2_curves = { git = "https://github.com/han0110/halo2curves", branch = "fix/impl-fq2-to-repr", package = "halo2curves" }
+halo2_curves = { git = "https://github.com//privacy-scaling-explorations/halo2curves", tag = "0.2.1", package = "halo2curves" }
 
 [patch."https://github.com/privacy-scaling-explorations/halo2wrong"]
 halo2_wrong = { git = "https://github.com/han0110/halo2wrong", branch = "feature/range-chip-with-tagged-table", package = "halo2wrong" }

--- a/src/loader/evm/test.rs
+++ b/src/loader/evm/test.rs
@@ -1,7 +1,7 @@
 use crate::{loader::evm::test::tui::Tui, util::Itertools};
 use foundry_evm::{
     executor::{backend::Backend, fork::MultiFork, ExecutorBuilder},
-    revm::AccountInfo,
+    revm::{AccountInfo, Bytecode},
     utils::h256_to_u256_be,
     Address,
 };
@@ -33,8 +33,10 @@ pub fn execute(code: Vec<u8>, calldata: Vec<u8>) -> (bool, u64, Vec<u64>) {
         .set_debugger(debug)
         .build(Backend::new(MultiFork::new().0, None));
 
-    evm.backend_mut()
-        .insert_account_info(callee, AccountInfo::new(0.into(), 1, code.into()));
+    evm.backend_mut().insert_account_info(
+        callee,
+        AccountInfo::new(0.into(), 1, Bytecode::new_raw(code.into())),
+    );
 
     let result = evm
         .call_raw(caller, callee, calldata.into(), 0.into())


### PR DESCRIPTION
- Upgrade and pin `foundry_evm` version to [`93ee742`](https://github.com/foundry-rs/foundry/tree/93ee742dd0854d7ceb52cc081bc25babfaac9379)
- Upgrade `halo2_curve` to `0.2.1`