### PR TITLE
General refactor for further integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,18 @@ num-bigint = "0.4.3"
 num-integer = "0.1.45"
 num-traits = "0.2.15"
 rand = "0.8"
+hex = "0.4"
 halo2_curves = { git = "https://github.com/privacy-scaling-explorations/halo2curves", tag = "0.3.0", package = "halo2curves" }
 
 # system_halo2
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2", tag = "v2022_10_22", optional = true }
 
 # loader_evm
-ethereum_types = { package = "ethereum-types", version = "0.13.1", default-features = false, features = ["std"], optional = true }
-sha3 = { version = "0.10.1", optional = true }
+ethereum_types = { package = "ethereum-types", version = "0.13", default-features = false, features = ["std"], optional = true }
+sha3 = { version = "0.10", optional = true }
+revm = { version = "2.1.0", optional = true }
+bytes = { version = "1.2", optional = true }
+rlp = { version = "0.5", default-features = false, features = ["std"], optional = true }
 
 # loader_halo2
 halo2_wrong_ecc = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2022_10_22", package = "ecc", optional = true }
@@ -31,14 +35,13 @@ paste = "1.0.7"
 halo2_wrong_ecc = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2022_10_22", package = "ecc" }
 
 # loader_evm
-foundry_evm = { git = "https://github.com/foundry-rs/foundry", package = "foundry-evm", rev = "6b1ee60e" }
-crossterm = { version = "0.22.1" }
-tui = { version = "0.16.0", default-features = false, features = ["crossterm"] }
+crossterm = { version = "0.25" }
+tui = { version = "0.19", default-features = false, features = ["crossterm"] }
 
 [features]
 default = ["loader_evm", "loader_halo2", "system_halo2"]
 
-loader_evm = ["dep:ethereum_types", "dep:sha3"]
+loader_evm = ["dep:ethereum_types", "dep:sha3", "dep:revm", "dep:bytes", "dep:rlp"]
 loader_halo2 = ["dep:halo2_proofs", "dep:halo2_wrong_ecc", "dep:poseidon"]
 
 system_halo2 = ["dep:halo2_proofs"]

--- a/examples/evm-verifier-with-accumulator.rs
+++ b/examples/evm-verifier-with-accumulator.rs
@@ -443,7 +443,7 @@ mod aggregation {
                     let KzgAccumulator { lhs, rhs } =
                         aggregate(&self.svk, &loader, &self.snarks, self.as_proof());
 
-                    Ok((lhs.assigned(), rhs.assigned()))
+                    Ok((lhs.into_assigned(), rhs.into_assigned()))
                 },
             )?;
 

--- a/examples/evm-verifier-with-accumulator.rs
+++ b/examples/evm-verifier-with-accumulator.rs
@@ -1,5 +1,4 @@
 use ethereum_types::Address;
-use foundry_evm::executor::{fork::MultiFork, Backend, ExecutorBuilder};
 use halo2_curves::bn256::{Bn256, Fq, Fr, G1Affine};
 use halo2_proofs::{
     dev::MockProver,
@@ -18,7 +17,7 @@ use halo2_proofs::{
 use itertools::Itertools;
 use plonk_verifier::{
     loader::{
-        evm::{encode_calldata, EvmLoader},
+        evm::{encode_calldata, EvmLoader, ExecutorBuilder},
         native::NativeLoader,
     },
     pcs::kzg::{Gwc19, Kzg, KzgAs, LimbsEncoding},
@@ -574,16 +573,14 @@ fn evm_verify(deployment_code: Vec<u8>, instances: Vec<Vec<Fr>>, proof: Vec<u8>)
     let success = {
         let mut evm = ExecutorBuilder::default()
             .with_gas_limit(u64::MAX.into())
-            .build(Backend::new(MultiFork::new().0, None));
+            .build();
 
         let caller = Address::from_low_u64_be(0xfe);
         let verifier = evm
-            .deploy(caller, deployment_code.into(), 0.into(), None)
-            .unwrap()
-            .address;
-        let result = evm
-            .call_raw(caller, verifier, calldata.into(), 0.into())
+            .deploy(caller, deployment_code.into(), 0.into())
+            .address
             .unwrap();
+        let result = evm.call_raw(caller, verifier, calldata.into(), 0.into());
 
         dbg!(result.gas_used);
 

--- a/src/loader/evm.rs
+++ b/src/loader/evm.rs
@@ -6,7 +6,9 @@ mod util;
 mod test;
 
 pub use loader::{EcPoint, EvmLoader, Scalar};
-pub use util::{encode_calldata, estimate_gas, fe_to_u256, modulus, u256_to_fe, MemoryChunk};
+pub use util::{
+    encode_calldata, estimate_gas, fe_to_u256, modulus, u256_to_fe, ExecutorBuilder, MemoryChunk,
+};
 
 pub use ethereum_types::U256;
 

--- a/src/loader/evm/test.rs
+++ b/src/loader/evm/test.rs
@@ -1,10 +1,9 @@
-use crate::{loader::evm::test::tui::Tui, util::Itertools};
-use foundry_evm::{
-    executor::{backend::Backend, fork::MultiFork, ExecutorBuilder},
-    revm::{AccountInfo, Bytecode},
-    utils::h256_to_u256_be,
-    Address,
+use crate::{
+    loader::evm::{test::tui::Tui, util::ExecutorBuilder},
+    util::Itertools,
 };
+use ethereum_types::{Address, U256};
+use revm::{AccountInfo, Bytecode};
 use std::env::var_os;
 
 mod tui;
@@ -29,23 +28,20 @@ pub fn execute(code: Vec<u8>, calldata: Vec<u8>) -> (bool, u64, Vec<u64>) {
 
     let mut evm = ExecutorBuilder::default()
         .with_gas_limit(u64::MAX.into())
-        .set_tracing(debug)
         .set_debugger(debug)
-        .build(Backend::new(MultiFork::new().0, None));
+        .build();
 
-    evm.backend_mut().insert_account_info(
+    evm.db_mut().insert_account_info(
         callee,
         AccountInfo::new(0.into(), 1, Bytecode::new_raw(code.into())),
     );
 
-    let result = evm
-        .call_raw(caller, callee, calldata.into(), 0.into())
-        .unwrap();
+    let result = evm.call_raw(caller, callee, calldata.into(), 0.into());
 
     let costs = result
         .logs
         .into_iter()
-        .map(|log| h256_to_u256_be(log.topics[0]).as_u64())
+        .map(|log| U256::from_big_endian(log.topics[0].as_bytes()).as_u64())
         .collect_vec();
 
     if debug {

--- a/src/loader/evm/test/tui.rs
+++ b/src/loader/evm/test/tui.rs
@@ -1,5 +1,6 @@
 //! Copied and modified from https://github.com/foundry-rs/foundry/blob/master/ui/src/lib.rs
 
+use crate::loader::evm::util::executor::{CallKind, DebugStep};
 use crossterm::{
     event::{
         self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyModifiers,
@@ -8,11 +9,8 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use foundry_evm::{
-    debug::{DebugStep, Instruction},
-    revm::opcode,
-    Address, CallKind,
-};
+use ethereum_types::Address;
+use revm::opcode;
 use std::{
     cmp::{max, min},
     io,
@@ -618,12 +616,7 @@ impl Tui {
             .borders(Borders::ALL);
         let min_len = usize::max(format!("{}", stack.len()).len(), 2);
 
-        let indices_affected =
-            if let Instruction::OpCode(op) = debug_steps[current_step].instruction {
-                stack_indices_affected(op)
-            } else {
-                vec![]
-            };
+        let indices_affected = stack_indices_affected(debug_steps[current_step].instruction.0);
 
         let text: Vec<Spans> = stack
             .iter()
@@ -699,33 +692,29 @@ impl Tui {
 
         let mut word = None;
         let mut color = None;
-        if let Instruction::OpCode(op) = debug_steps[current_step].instruction {
-            let stack_len = debug_steps[current_step].stack.len();
-            if stack_len > 0 {
-                let w = debug_steps[current_step].stack[stack_len - 1];
-                match op {
-                    opcode::MLOAD => {
-                        word = Some(w.as_usize() / 32);
-                        color = Some(Color::Cyan);
-                    }
-                    opcode::MSTORE => {
-                        word = Some(w.as_usize() / 32);
-                        color = Some(Color::Red);
-                    }
-                    _ => {}
+        let stack_len = debug_steps[current_step].stack.len();
+        if stack_len > 0 {
+            let w = debug_steps[current_step].stack[stack_len - 1];
+            match debug_steps[current_step].instruction.0 {
+                opcode::MLOAD => {
+                    word = Some(w.as_usize() / 32);
+                    color = Some(Color::Cyan);
                 }
+                opcode::MSTORE => {
+                    word = Some(w.as_usize() / 32);
+                    color = Some(Color::Red);
+                }
+                _ => {}
             }
         }
 
         if current_step > 0 {
             let prev_step = current_step - 1;
             let stack_len = debug_steps[prev_step].stack.len();
-            if let Instruction::OpCode(op) = debug_steps[prev_step].instruction {
-                if op == opcode::MSTORE {
-                    let prev_top = debug_steps[prev_step].stack[stack_len - 1];
-                    word = Some(prev_top.as_usize() / 32);
-                    color = Some(Color::Green);
-                }
+            if debug_steps[prev_step].instruction.0 == opcode::MSTORE {
+                let prev_top = debug_steps[prev_step].stack[stack_len - 1];
+                word = Some(prev_top.as_usize() / 32);
+                color = Some(Color::Green);
             }
         }
 

--- a/src/loader/evm/test/tui.rs
+++ b/src/loader/evm/test/tui.rs
@@ -88,7 +88,7 @@ impl Tui {
         self.terminal.clear().unwrap();
         let mut draw_memory: DrawMemory = DrawMemory::default();
 
-        let debug_call: Vec<(Address, Vec<DebugStep>, CallKind)> = self.debug_arena.clone();
+        let debug_call = &self.debug_arena;
         let mut opcode_list: Vec<String> = debug_call[0]
             .1
             .iter()
@@ -205,7 +205,7 @@ impl Tui {
                     }
                     KeyCode::Char('s') => {
                         for _ in 0..Tui::buffer_as_number(&self.key_buffer, 1) {
-                            let remaining_ops = opcode_list[self.current_step..].to_vec().clone();
+                            let remaining_ops = &opcode_list[self.current_step..];
                             self.current_step += remaining_ops
                                 .iter()
                                 .enumerate()
@@ -231,7 +231,7 @@ impl Tui {
                     }
                     KeyCode::Char('a') => {
                         for _ in 0..Tui::buffer_as_number(&self.key_buffer, 1) {
-                            let prev_ops = opcode_list[..self.current_step].to_vec().clone();
+                            let prev_ops = &opcode_list[..self.current_step];
                             self.current_step = prev_ops
                                 .iter()
                                 .enumerate()

--- a/src/loader/evm/util.rs
+++ b/src/loader/evm/util.rs
@@ -5,6 +5,10 @@ use crate::{
 use ethereum_types::U256;
 use std::iter;
 
+pub(crate) mod executor;
+
+pub use executor::ExecutorBuilder;
+
 pub struct MemoryChunk {
     ptr: usize,
     len: usize,

--- a/src/loader/evm/util/executor.rs
+++ b/src/loader/evm/util/executor.rs
@@ -1,0 +1,868 @@
+//! Copied and modified from https://github.com/foundry-rs/foundry/blob/master/evm/src/executor/mod.rs
+
+use bytes::Bytes;
+use ethereum_types::{Address, H256, U256, U64};
+use revm::{
+    evm_inner, opcode, spec_opcode_gas, Account, BlockEnv, CallInputs, CallScheme, CreateInputs,
+    CreateScheme, Database, DatabaseCommit, EVMData, Env, ExecutionResult, Gas, GasInspector,
+    InMemoryDB, Inspector, Interpreter, Memory, OpCode, Return, TransactOut, TransactTo, TxEnv,
+};
+use sha3::{Digest, Keccak256};
+use std::{cell::RefCell, collections::HashMap, fmt::Display, rc::Rc};
+
+macro_rules! return_ok {
+    () => {
+        Return::Continue | Return::Stop | Return::Return | Return::SelfDestruct
+    };
+}
+
+fn keccak256(data: impl AsRef<[u8]>) -> [u8; 32] {
+    Keccak256::digest(data.as_ref()).into()
+}
+
+fn get_contract_address(sender: impl Into<Address>, nonce: impl Into<U256>) -> Address {
+    let mut stream = rlp::RlpStream::new();
+    stream.begin_list(2);
+    stream.append(&sender.into());
+    stream.append(&nonce.into());
+
+    let hash = keccak256(&stream.out());
+
+    let mut bytes = [0u8; 20];
+    bytes.copy_from_slice(&hash[12..]);
+    Address::from(bytes)
+}
+
+fn get_create2_address(
+    from: impl Into<Address>,
+    salt: [u8; 32],
+    init_code: impl Into<Bytes>,
+) -> Address {
+    get_create2_address_from_hash(from, salt, keccak256(init_code.into().as_ref()).to_vec())
+}
+
+fn get_create2_address_from_hash(
+    from: impl Into<Address>,
+    salt: [u8; 32],
+    init_code_hash: impl Into<Bytes>,
+) -> Address {
+    let bytes = [
+        &[0xff],
+        from.into().as_bytes(),
+        salt.as_slice(),
+        init_code_hash.into().as_ref(),
+    ]
+    .concat();
+
+    let hash = keccak256(&bytes);
+
+    let mut bytes = [0u8; 20];
+    bytes.copy_from_slice(&hash[12..]);
+    Address::from(bytes)
+}
+
+fn get_create_address(call: &CreateInputs, nonce: u64) -> Address {
+    match call.scheme {
+        CreateScheme::Create => get_contract_address(call.caller, nonce),
+        CreateScheme::Create2 { salt } => {
+            let mut buffer: [u8; 4 * 8] = [0; 4 * 8];
+            salt.to_big_endian(&mut buffer);
+            get_create2_address(call.caller, buffer, call.init_code.clone())
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Log {
+    pub address: Address,
+    pub topics: Vec<H256>,
+    pub data: Bytes,
+    pub block_hash: Option<H256>,
+    pub block_number: Option<U64>,
+    pub transaction_hash: Option<H256>,
+    pub transaction_index: Option<U64>,
+    pub log_index: Option<U256>,
+    pub transaction_log_index: Option<U256>,
+    pub log_type: Option<String>,
+    pub removed: Option<bool>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct LogCollector {
+    logs: Vec<Log>,
+}
+
+impl<DB: Database> Inspector<DB> for LogCollector {
+    fn log(&mut self, _: &mut EVMData<'_, DB>, address: &Address, topics: &[H256], data: &Bytes) {
+        self.logs.push(Log {
+            address: *address,
+            topics: topics.to_vec(),
+            data: data.clone(),
+            ..Default::default()
+        });
+    }
+
+    fn call(
+        &mut self,
+        _: &mut EVMData<'_, DB>,
+        call: &mut CallInputs,
+        _: bool,
+    ) -> (Return, Gas, Bytes) {
+        (Return::Continue, Gas::new(call.gas_limit), Bytes::new())
+    }
+}
+
+#[derive(Clone, Debug, Copy)]
+pub enum CallKind {
+    Call,
+    StaticCall,
+    CallCode,
+    DelegateCall,
+    Create,
+    Create2,
+}
+
+impl Default for CallKind {
+    fn default() -> Self {
+        CallKind::Call
+    }
+}
+
+impl From<CallScheme> for CallKind {
+    fn from(scheme: CallScheme) -> Self {
+        match scheme {
+            CallScheme::Call => CallKind::Call,
+            CallScheme::StaticCall => CallKind::StaticCall,
+            CallScheme::CallCode => CallKind::CallCode,
+            CallScheme::DelegateCall => CallKind::DelegateCall,
+        }
+    }
+}
+
+impl From<CreateScheme> for CallKind {
+    fn from(create: CreateScheme) -> Self {
+        match create {
+            CreateScheme::Create => CallKind::Create,
+            CreateScheme::Create2 { .. } => CallKind::Create2,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DebugArena {
+    pub arena: Vec<DebugNode>,
+}
+
+impl DebugArena {
+    fn push_node(&mut self, mut new_node: DebugNode) -> usize {
+        fn recursively_push(
+            arena: &mut Vec<DebugNode>,
+            entry: usize,
+            mut new_node: DebugNode,
+        ) -> usize {
+            match new_node.depth {
+                _ if arena[entry].depth == new_node.depth - 1 => {
+                    let id = arena.len();
+                    new_node.location = arena[entry].children.len();
+                    new_node.parent = Some(entry);
+                    arena[entry].children.push(id);
+                    arena.push(new_node);
+                    id
+                }
+                _ => {
+                    let child = *arena[entry].children.last().unwrap();
+                    recursively_push(arena, child, new_node)
+                }
+            }
+        }
+
+        if self.arena.is_empty() {
+            self.arena.push(new_node);
+            0
+        } else if new_node.depth == 0 {
+            let id = self.arena.len();
+            new_node.location = self.arena[0].children.len();
+            new_node.parent = Some(0);
+            self.arena[0].children.push(id);
+            self.arena.push(new_node);
+            id
+        } else {
+            recursively_push(&mut self.arena, 0, new_node)
+        }
+    }
+
+    #[cfg(test)]
+    pub fn flatten(&self, entry: usize) -> Vec<(Address, Vec<DebugStep>, CallKind)> {
+        let node = &self.arena[entry];
+
+        let mut flattened = vec![];
+        if !node.steps.is_empty() {
+            flattened.push((node.address, node.steps.clone(), node.kind));
+        }
+        flattened.extend(node.children.iter().flat_map(|child| self.flatten(*child)));
+
+        flattened
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DebugNode {
+    pub parent: Option<usize>,
+    pub children: Vec<usize>,
+    pub location: usize,
+    pub address: Address,
+    pub kind: CallKind,
+    pub depth: usize,
+    pub steps: Vec<DebugStep>,
+}
+
+#[derive(Clone, Debug)]
+pub struct DebugStep {
+    pub stack: Vec<U256>,
+    pub memory: Memory,
+    pub instruction: Instruction,
+    pub push_bytes: Option<Vec<u8>>,
+    pub pc: usize,
+    pub total_gas_used: u64,
+}
+
+impl Default for DebugStep {
+    fn default() -> Self {
+        Self {
+            stack: vec![],
+            memory: Memory::new(),
+            instruction: Instruction(revm::opcode::INVALID),
+            push_bytes: None,
+            pc: 0,
+            total_gas_used: 0,
+        }
+    }
+}
+
+impl DebugStep {
+    #[cfg(test)]
+    pub fn pretty_opcode(&self) -> String {
+        if let Some(push_bytes) = &self.push_bytes {
+            format!("{}(0x{})", self.instruction, hex::encode(push_bytes))
+        } else {
+            self.instruction.to_string()
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Instruction(pub u8);
+
+impl From<u8> for Instruction {
+    fn from(op: u8) -> Instruction {
+        Instruction(op)
+    }
+}
+
+impl Display for Instruction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            OpCode::try_from_u8(self.0).map_or_else(
+                || format!("UNDEFINED(0x{:02x})", self.0),
+                |opcode| opcode.as_str().to_string(),
+            )
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Debugger {
+    arena: DebugArena,
+    head: usize,
+    context: Address,
+    gas_inspector: Rc<RefCell<GasInspector>>,
+}
+
+impl Debugger {
+    fn new(gas_inspector: Rc<RefCell<GasInspector>>) -> Self {
+        Self {
+            arena: Default::default(),
+            head: Default::default(),
+            context: Default::default(),
+            gas_inspector,
+        }
+    }
+
+    fn enter(&mut self, depth: usize, address: Address, kind: CallKind) {
+        self.context = address;
+        self.head = self.arena.push_node(DebugNode {
+            depth,
+            address,
+            kind,
+            ..Default::default()
+        });
+    }
+
+    fn exit(&mut self) {
+        if let Some(parent_id) = self.arena.arena[self.head].parent {
+            let DebugNode {
+                depth,
+                address,
+                kind,
+                ..
+            } = self.arena.arena[parent_id];
+            self.context = address;
+            self.head = self.arena.push_node(DebugNode {
+                depth,
+                address,
+                kind,
+                ..Default::default()
+            });
+        }
+    }
+}
+
+impl<DB: Database> Inspector<DB> for Debugger {
+    fn step(
+        &mut self,
+        interpreter: &mut Interpreter,
+        data: &mut EVMData<'_, DB>,
+        _is_static: bool,
+    ) -> Return {
+        let pc = interpreter.program_counter();
+        let op = interpreter.contract.bytecode.bytecode()[pc];
+
+        let opcode_infos = spec_opcode_gas(data.env.cfg.spec_id);
+        let opcode_info = &opcode_infos[op as usize];
+
+        let push_size = if opcode_info.is_push() {
+            (op - opcode::PUSH1 + 1) as usize
+        } else {
+            0
+        };
+        let push_bytes = match push_size {
+            0 => None,
+            n => {
+                let start = pc + 1;
+                let end = start + n;
+                Some(interpreter.contract.bytecode.bytecode()[start..end].to_vec())
+            }
+        };
+
+        let spent = interpreter.gas.limit() - self.gas_inspector.borrow().gas_remaining();
+        let total_gas_used = spent - (interpreter.gas.refunded() as u64).min(spent / 5);
+
+        self.arena.arena[self.head].steps.push(DebugStep {
+            pc,
+            stack: interpreter.stack().data().clone(),
+            memory: interpreter.memory.clone(),
+            instruction: Instruction(op),
+            push_bytes,
+            total_gas_used,
+        });
+
+        Return::Continue
+    }
+
+    fn call(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        call: &mut CallInputs,
+        _: bool,
+    ) -> (Return, Gas, Bytes) {
+        self.enter(
+            data.journaled_state.depth() as usize,
+            call.context.code_address,
+            call.context.scheme.into(),
+        );
+
+        (Return::Continue, Gas::new(call.gas_limit), Bytes::new())
+    }
+
+    fn call_end(
+        &mut self,
+        _: &mut EVMData<'_, DB>,
+        _: &CallInputs,
+        gas: Gas,
+        status: Return,
+        retdata: Bytes,
+        _: bool,
+    ) -> (Return, Gas, Bytes) {
+        self.exit();
+
+        (status, gas, retdata)
+    }
+
+    fn create(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        call: &mut CreateInputs,
+    ) -> (Return, Option<Address>, Gas, Bytes) {
+        let nonce = data.journaled_state.account(call.caller).info.nonce;
+        self.enter(
+            data.journaled_state.depth() as usize,
+            get_create_address(call, nonce),
+            CallKind::Create,
+        );
+
+        (
+            Return::Continue,
+            None,
+            Gas::new(call.gas_limit),
+            Bytes::new(),
+        )
+    }
+
+    fn create_end(
+        &mut self,
+        _: &mut EVMData<'_, DB>,
+        _: &CreateInputs,
+        status: Return,
+        address: Option<Address>,
+        gas: Gas,
+        retdata: Bytes,
+    ) -> (Return, Option<Address>, Gas, Bytes) {
+        self.exit();
+
+        (status, address, gas, retdata)
+    }
+}
+
+#[macro_export]
+macro_rules! call_inspectors {
+    ($id:ident, [ $($inspector:expr),+ ], $call:block) => {
+        $({
+            if let Some($id) = $inspector {
+                $call;
+            }
+        })+
+    }
+}
+
+struct InspectorData {
+    logs: Vec<Log>,
+    debug: Option<DebugArena>,
+}
+
+#[derive(Default)]
+struct InspectorStack {
+    gas: Option<Rc<RefCell<GasInspector>>>,
+    logs: Option<LogCollector>,
+    debugger: Option<Debugger>,
+}
+
+impl InspectorStack {
+    fn collect_inspector_states(self) -> InspectorData {
+        InspectorData {
+            logs: self.logs.map(|logs| logs.logs).unwrap_or_default(),
+            debug: self.debugger.map(|debugger| debugger.arena),
+        }
+    }
+}
+
+impl<DB: Database> Inspector<DB> for InspectorStack {
+    fn initialize_interp(
+        &mut self,
+        interpreter: &mut Interpreter,
+        data: &mut EVMData<'_, DB>,
+        is_static: bool,
+    ) -> Return {
+        call_inspectors!(
+            inspector,
+            [
+                &mut self.gas.as_deref().map(|gas| gas.borrow_mut()),
+                &mut self.logs,
+                &mut self.debugger
+            ],
+            {
+                let status = inspector.initialize_interp(interpreter, data, is_static);
+
+                if status != Return::Continue {
+                    return status;
+                }
+            }
+        );
+
+        Return::Continue
+    }
+
+    fn step(
+        &mut self,
+        interpreter: &mut Interpreter,
+        data: &mut EVMData<'_, DB>,
+        is_static: bool,
+    ) -> Return {
+        call_inspectors!(
+            inspector,
+            [
+                &mut self.gas.as_deref().map(|gas| gas.borrow_mut()),
+                &mut self.logs,
+                &mut self.debugger
+            ],
+            {
+                let status = inspector.step(interpreter, data, is_static);
+
+                if status != Return::Continue {
+                    return status;
+                }
+            }
+        );
+
+        Return::Continue
+    }
+
+    fn log(
+        &mut self,
+        evm_data: &mut EVMData<'_, DB>,
+        address: &Address,
+        topics: &[H256],
+        data: &Bytes,
+    ) {
+        call_inspectors!(inspector, [&mut self.logs], {
+            inspector.log(evm_data, address, topics, data);
+        });
+    }
+
+    fn step_end(
+        &mut self,
+        interpreter: &mut Interpreter,
+        data: &mut EVMData<'_, DB>,
+        is_static: bool,
+        status: Return,
+    ) -> Return {
+        call_inspectors!(
+            inspector,
+            [
+                &mut self.gas.as_deref().map(|gas| gas.borrow_mut()),
+                &mut self.logs,
+                &mut self.debugger
+            ],
+            {
+                let status = inspector.step_end(interpreter, data, is_static, status);
+
+                if status != Return::Continue {
+                    return status;
+                }
+            }
+        );
+
+        Return::Continue
+    }
+
+    fn call(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        call: &mut CallInputs,
+        is_static: bool,
+    ) -> (Return, Gas, Bytes) {
+        call_inspectors!(
+            inspector,
+            [
+                &mut self.gas.as_deref().map(|gas| gas.borrow_mut()),
+                &mut self.logs,
+                &mut self.debugger
+            ],
+            {
+                let (status, gas, retdata) = inspector.call(data, call, is_static);
+
+                if status != Return::Continue {
+                    return (status, gas, retdata);
+                }
+            }
+        );
+
+        (Return::Continue, Gas::new(call.gas_limit), Bytes::new())
+    }
+
+    fn call_end(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        call: &CallInputs,
+        remaining_gas: Gas,
+        status: Return,
+        retdata: Bytes,
+        is_static: bool,
+    ) -> (Return, Gas, Bytes) {
+        call_inspectors!(
+            inspector,
+            [
+                &mut self.gas.as_deref().map(|gas| gas.borrow_mut()),
+                &mut self.logs,
+                &mut self.debugger
+            ],
+            {
+                let (new_status, new_gas, new_retdata) = inspector.call_end(
+                    data,
+                    call,
+                    remaining_gas,
+                    status,
+                    retdata.clone(),
+                    is_static,
+                );
+
+                if new_status != status || (new_status == Return::Revert && new_retdata != retdata)
+                {
+                    return (new_status, new_gas, new_retdata);
+                }
+            }
+        );
+
+        (status, remaining_gas, retdata)
+    }
+
+    fn create(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        call: &mut CreateInputs,
+    ) -> (Return, Option<Address>, Gas, Bytes) {
+        call_inspectors!(
+            inspector,
+            [
+                &mut self.gas.as_deref().map(|gas| gas.borrow_mut()),
+                &mut self.logs,
+                &mut self.debugger
+            ],
+            {
+                let (status, addr, gas, retdata) = inspector.create(data, call);
+
+                if status != Return::Continue {
+                    return (status, addr, gas, retdata);
+                }
+            }
+        );
+
+        (
+            Return::Continue,
+            None,
+            Gas::new(call.gas_limit),
+            Bytes::new(),
+        )
+    }
+
+    fn create_end(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        call: &CreateInputs,
+        status: Return,
+        address: Option<Address>,
+        remaining_gas: Gas,
+        retdata: Bytes,
+    ) -> (Return, Option<Address>, Gas, Bytes) {
+        call_inspectors!(
+            inspector,
+            [
+                &mut self.gas.as_deref().map(|gas| gas.borrow_mut()),
+                &mut self.logs,
+                &mut self.debugger
+            ],
+            {
+                let (new_status, new_address, new_gas, new_retdata) = inspector.create_end(
+                    data,
+                    call,
+                    status,
+                    address,
+                    remaining_gas,
+                    retdata.clone(),
+                );
+
+                if new_status != status {
+                    return (new_status, new_address, new_gas, new_retdata);
+                }
+            }
+        );
+
+        (status, address, remaining_gas, retdata)
+    }
+
+    fn selfdestruct(&mut self) {
+        call_inspectors!(inspector, [&mut self.logs, &mut self.debugger], {
+            Inspector::<DB>::selfdestruct(inspector);
+        });
+    }
+}
+
+pub struct RawCallResult {
+    pub exit_reason: Return,
+    pub reverted: bool,
+    pub result: Bytes,
+    pub gas_used: u64,
+    pub gas_refunded: u64,
+    pub logs: Vec<Log>,
+    pub debug: Option<DebugArena>,
+    pub state_changeset: Option<HashMap<Address, Account>>,
+    pub env: Env,
+    pub out: TransactOut,
+}
+
+#[derive(Clone, Debug)]
+pub struct DeployResult {
+    pub exit_reason: Return,
+    pub reverted: bool,
+    pub address: Option<Address>,
+    pub gas_used: u64,
+    pub gas_refunded: u64,
+    pub logs: Vec<Log>,
+    pub debug: Option<DebugArena>,
+    pub env: Env,
+}
+
+#[derive(Debug, Default)]
+pub struct ExecutorBuilder {
+    debugger: bool,
+    gas_limit: Option<U256>,
+}
+
+impl ExecutorBuilder {
+    pub fn set_debugger(mut self, enable: bool) -> Self {
+        self.debugger = enable;
+        self
+    }
+
+    pub fn with_gas_limit(mut self, gas_limit: U256) -> Self {
+        self.gas_limit = Some(gas_limit);
+        self
+    }
+
+    pub fn build(self) -> Executor {
+        Executor::new(self.debugger, self.gas_limit.unwrap_or(U256::MAX))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Executor {
+    db: InMemoryDB,
+    debugger: bool,
+    gas_limit: U256,
+}
+
+impl Executor {
+    fn new(debugger: bool, gas_limit: U256) -> Self {
+        Executor {
+            db: InMemoryDB::default(),
+            debugger,
+            gas_limit,
+        }
+    }
+
+    pub fn db_mut(&mut self) -> &mut InMemoryDB {
+        &mut self.db
+    }
+
+    pub fn deploy(&mut self, from: Address, code: Bytes, value: U256) -> DeployResult {
+        let env = self.build_test_env(from, TransactTo::Create(CreateScheme::Create), code, value);
+        let result = self.call_raw_with_env(env);
+        self.commit(&result);
+
+        let RawCallResult {
+            exit_reason,
+            out,
+            gas_used,
+            gas_refunded,
+            logs,
+            debug,
+            env,
+            ..
+        } = result;
+
+        let address = match (exit_reason, out) {
+            (return_ok!(), TransactOut::Create(_, Some(address))) => Some(address),
+            _ => None,
+        };
+
+        DeployResult {
+            exit_reason,
+            reverted: !matches!(exit_reason, return_ok!()),
+            address,
+            gas_used,
+            gas_refunded,
+            logs,
+            debug,
+            env,
+        }
+    }
+
+    pub fn call_raw(
+        &self,
+        from: Address,
+        to: Address,
+        calldata: Bytes,
+        value: U256,
+    ) -> RawCallResult {
+        let env = self.build_test_env(from, TransactTo::Call(to), calldata, value);
+        self.call_raw_with_env(env)
+    }
+
+    fn call_raw_with_env(&self, mut env: Env) -> RawCallResult {
+        let mut inspector = self.inspector();
+        let result =
+            evm_inner::<_, true>(&mut env, &mut self.db.clone(), &mut inspector).transact();
+        let (exec_result, state_changeset) = result;
+        let ExecutionResult {
+            exit_reason,
+            gas_refunded,
+            gas_used,
+            out,
+            ..
+        } = exec_result;
+
+        let result = match out {
+            TransactOut::Call(ref data) => data.to_owned(),
+            _ => Bytes::default(),
+        };
+        let InspectorData { logs, debug } = inspector.collect_inspector_states();
+
+        RawCallResult {
+            exit_reason,
+            reverted: !matches!(exit_reason, return_ok!()),
+            result,
+            gas_used,
+            gas_refunded,
+            logs: logs.to_vec(),
+            debug,
+            state_changeset: Some(state_changeset.into_iter().collect()),
+            env,
+            out,
+        }
+    }
+
+    fn commit(&mut self, result: &RawCallResult) {
+        if let Some(state_changeset) = result.state_changeset.as_ref() {
+            self.db
+                .commit(state_changeset.clone().into_iter().collect());
+        }
+    }
+
+    fn inspector(&self) -> InspectorStack {
+        let mut stack = InspectorStack {
+            logs: Some(LogCollector::default()),
+            ..Default::default()
+        };
+        if self.debugger {
+            let gas_inspector = Rc::new(RefCell::new(GasInspector::default()));
+            stack.gas = Some(gas_inspector.clone());
+            stack.debugger = Some(Debugger::new(gas_inspector));
+        }
+        stack
+    }
+
+    fn build_test_env(
+        &self,
+        caller: Address,
+        transact_to: TransactTo,
+        data: Bytes,
+        value: U256,
+    ) -> Env {
+        Env {
+            block: BlockEnv {
+                gas_limit: self.gas_limit,
+                ..BlockEnv::default()
+            },
+            tx: TxEnv {
+                caller,
+                transact_to,
+                data,
+                value,
+                gas_limit: self.gas_limit.as_u64(),
+                ..TxEnv::default()
+            },
+            ..Env::default()
+        }
+    }
+}

--- a/src/loader/halo2.rs
+++ b/src/loader/halo2.rs
@@ -62,7 +62,7 @@ where
             quotient: self.quotient.clone(),
             transcript_initial_state,
             instance_committing_key: self.instance_committing_key.clone(),
-            linearization: self.linearization.clone(),
+            linearization: self.linearization,
             accumulator_indices: self.accumulator_indices.clone(),
         }
     }

--- a/src/loader/halo2.rs
+++ b/src/loader/halo2.rs
@@ -23,7 +23,7 @@ mod util {
             Self: Sized,
             F: FnMut(B, V) -> B,
         {
-            self.into_iter().fold(Value::known(init), |acc, value| {
+            self.fold(Value::known(init), |acc, value| {
                 acc.zip(value).map(|(acc, value)| f(acc, value))
             })
         }
@@ -49,9 +49,7 @@ where
             self.transcript_initial_state
                 .as_ref()
                 .map(|transcript_initial_state| {
-                    loader.assign_scalar(circuit::Value::known(
-                        loader.scalar_chip().integer(*transcript_initial_state),
-                    ))
+                    loader.assign_scalar(circuit::Value::known(*transcript_initial_state))
                 });
         Protocol {
             domain: self.domain.clone(),

--- a/src/loader/halo2/loader.rs
+++ b/src/loader/halo2/loader.rs
@@ -71,7 +71,7 @@ impl<'a, C: CurveAffine, EccChip: EccInstructions<'a, C>> Halo2Loader<'a, C, Ecc
 
     pub fn assign_scalar(
         self: &Rc<Self>,
-        scalar: circuit::Value<EccChip::Scalar>,
+        scalar: circuit::Value<C::Scalar>,
     ) -> Scalar<'a, C, EccChip> {
         let assigned = self
             .scalar_chip()

--- a/src/loader/halo2/loader.rs
+++ b/src/loader/halo2/loader.rs
@@ -687,12 +687,8 @@ impl<'a, C: CurveAffine, EccChip: EccInstructions<'a, C>> EcPointLoader<C>
                 constant,
             )
             .unwrap();
-        let normalized = loader
-            .ecc_chip()
-            .normalize(&mut loader.ctx_mut(), &output)
-            .unwrap();
 
-        loader.ec_point_from_assigned(normalized)
+        loader.ec_point_from_assigned(output)
     }
 }
 

--- a/src/loader/halo2/shim.rs
+++ b/src/loader/halo2/shim.rs
@@ -13,15 +13,12 @@ pub trait Context: Debug {
 
 pub trait IntegerInstructions<'a, F: FieldExt>: Clone + Debug {
     type Context: Context;
-    type Integer: Clone + Debug;
     type AssignedInteger: Clone + Debug;
-
-    fn integer(&self, fe: F) -> Self::Integer;
 
     fn assign_integer(
         &self,
         ctx: &mut Self::Context,
-        integer: Value<Self::Integer>,
+        integer: Value<F>,
     ) -> Result<Self::AssignedInteger, Error>;
 
     fn assign_constant(
@@ -77,11 +74,9 @@ pub trait EccInstructions<'a, C: CurveAffine>: Clone + Debug {
         'a,
         C::Scalar,
         Context = Self::Context,
-        Integer = Self::Scalar,
         AssignedInteger = Self::AssignedScalar,
     >;
     type AssignedEcPoint: Clone + Debug;
-    type Scalar: Clone + Debug;
     type AssignedScalar: Clone + Debug;
 
     fn scalar_chip(&self) -> &Self::ScalarChip;
@@ -166,17 +161,12 @@ mod halo2_wrong {
 
     impl<'a, F: FieldExt> IntegerInstructions<'a, F> for MainGate<F> {
         type Context = RegionCtx<'a, F>;
-        type Integer = F;
         type AssignedInteger = AssignedCell<F, F>;
-
-        fn integer(&self, scalar: F) -> Self::Integer {
-            scalar
-        }
 
         fn assign_integer(
             &self,
             ctx: &mut Self::Context,
-            integer: Value<Self::Integer>,
+            integer: Value<F>,
         ) -> Result<Self::AssignedInteger, Error> {
             self.assign_value(ctx, integer)
         }
@@ -332,7 +322,6 @@ mod halo2_wrong {
         type Context = RegionCtx<'a, C::Scalar>;
         type ScalarChip = MainGate<C::Scalar>;
         type AssignedEcPoint = AssignedPoint<C::Base, C::Scalar, LIMBS, BITS>;
-        type Scalar = C::Scalar;
         type AssignedScalar = AssignedCell<C::Scalar, C::Scalar>;
 
         fn scalar_chip(&self) -> &Self::ScalarChip {

--- a/src/loader/native.rs
+++ b/src/loader/native.rs
@@ -54,10 +54,11 @@ impl<C: CurveAffine> EcPointLoader<C> for NativeLoader {
     }
 
     fn multi_scalar_multiplication(
-        pairs: &[(<Self as ScalarLoader<C::Scalar>>::LoadedScalar, C)],
+        pairs: &[(&<Self as ScalarLoader<C::Scalar>>::LoadedScalar, &C)],
     ) -> C {
         pairs
             .iter()
+            .cloned()
             .map(|(scalar, base)| *base * scalar)
             .reduce(|acc, value| acc + value)
             .unwrap()

--- a/src/pcs.rs
+++ b/src/pcs.rs
@@ -123,7 +123,7 @@ where
     L: Loader<C>,
     PCS: PolynomialCommitmentScheme<C, L>,
 {
-    fn from_repr(repr: Vec<L::LoadedScalar>) -> Result<PCS::Accumulator, Error>;
+    fn from_repr(repr: &[&L::LoadedScalar]) -> Result<PCS::Accumulator, Error>;
 }
 
 impl<C, L, PCS> AccumulatorEncoding<C, L, PCS> for ()
@@ -132,7 +132,7 @@ where
     L: Loader<C>,
     PCS: PolynomialCommitmentScheme<C, L>,
 {
-    fn from_repr(_: Vec<L::LoadedScalar>) -> Result<PCS::Accumulator, Error> {
+    fn from_repr(_: &[&L::LoadedScalar]) -> Result<PCS::Accumulator, Error> {
         unimplemented!()
     }
 }

--- a/src/pcs/kzg.rs
+++ b/src/pcs/kzg.rs
@@ -15,6 +15,9 @@ pub use accumulator::{KzgAccumulator, LimbsEncoding};
 pub use decider::KzgDecidingKey;
 pub use multiopen::{Bdfg21, Bdfg21Proof, Gwc19, Gwc19Proof};
 
+#[cfg(feature = "loader_halo2")]
+pub use accumulator::LimbsEncodingInstructions;
+
 #[derive(Clone, Debug)]
 pub struct Kzg<M, MOS>(PhantomData<(M, MOS)>);
 

--- a/src/pcs/kzg/accumulation.rs
+++ b/src/pcs/kzg/accumulation.rs
@@ -44,16 +44,16 @@ where
     ) -> Result<PCS::Accumulator, Error> {
         let (lhs, rhs) = instances
             .iter()
-            .cloned()
-            .map(|accumulator| (accumulator.lhs, accumulator.rhs))
-            .chain(proof.blind.clone())
+            .map(|accumulator| (&accumulator.lhs, &accumulator.rhs))
+            .chain(proof.blind.as_ref().map(|(lhs, rhs)| (lhs, rhs)))
             .unzip::<_, _, Vec<_>, Vec<_>>();
 
         let powers_of_r = proof.r.powers(lhs.len());
-        let [lhs, rhs] = [lhs, rhs].map(|msms| {
-            msms.into_iter()
+        let [lhs, rhs] = [lhs, rhs].map(|bases| {
+            bases
+                .into_iter()
                 .zip(powers_of_r.iter())
-                .map(|(msm, r)| Msm::<C, L>::base(msm) * r)
+                .map(|(base, r)| Msm::<C, L>::base(base) * r)
                 .sum::<Msm<_, _>>()
                 .evaluate(None)
         });
@@ -184,7 +184,7 @@ where
 
         let powers_of_r = r.powers(lhs.len());
         let [lhs, rhs] = [lhs, rhs].map(|msms| {
-            msms.into_iter()
+            msms.iter()
                 .zip(powers_of_r.iter())
                 .map(|(msm, power_of_r)| Msm::<C, NativeLoader>::base(msm) * power_of_r)
                 .sum::<Msm<_, _>>()

--- a/src/pcs/kzg/accumulator.rs
+++ b/src/pcs/kzg/accumulator.rs
@@ -188,7 +188,7 @@ mod halo2 {
                 },
             );
 
-            for (src, dst) in assigned_limbs.iter().zip(
+            for (src, dst) in assigned_limbs.iter().zip_eq(
                 iter::empty()
                     .chain(lhs.assigned().x().limbs())
                     .chain(lhs.assigned().y().limbs())

--- a/src/pcs/kzg/accumulator.rs
+++ b/src/pcs/kzg/accumulator.rs
@@ -132,9 +132,12 @@ mod evm {
 }
 
 #[cfg(feature = "loader_halo2")]
+pub use halo2::LimbsEncodingInstructions;
+
+#[cfg(feature = "loader_halo2")]
 mod halo2 {
     use crate::{
-        loader::halo2::{Context, EccInstructions, Halo2Loader, Scalar, Valuetools},
+        loader::halo2::{EccInstructions, Halo2Loader, Scalar, Valuetools},
         pcs::{
             kzg::{KzgAccumulator, LimbsEncoding},
             AccumulatorEncoding, PolynomialCommitmentScheme,
@@ -145,19 +148,18 @@ mod halo2 {
         },
         Error,
     };
-    use halo2_proofs::circuit::Value;
-    use halo2_wrong_ecc::{maingate::AssignedValue, AssignedPoint};
+    use halo2_proofs::{circuit::Value, plonk};
     use std::{iter, ops::Deref, rc::Rc};
 
-    fn ec_point_from_assigned_limbs<C: CurveAffine, const LIMBS: usize, const BITS: usize>(
-        limbs: &[impl Deref<Target = AssignedValue<C::Scalar>>],
+    fn ec_point_from_limbs<C: CurveAffine, const LIMBS: usize, const BITS: usize>(
+        limbs: &[Value<&C::Scalar>],
     ) -> Value<C> {
         assert_eq!(limbs.len(), 2 * LIMBS);
 
         let [x, y] = [&limbs[..LIMBS], &limbs[LIMBS..]].map(|limbs| {
             limbs
                 .iter()
-                .map(|assigned| assigned.value())
+                .cloned()
                 .fold_zipped(Vec::new(), |mut acc, limb| {
                     acc.push(*limb);
                     acc
@@ -166,6 +168,22 @@ mod halo2 {
         });
 
         x.zip(y).map(|(x, y)| C::from_xy(x, y).unwrap())
+    }
+
+    pub trait LimbsEncodingInstructions<'a, C: CurveAffine, const LIMBS: usize, const BITS: usize>:
+        EccInstructions<'a, C>
+    {
+        fn assign_ec_point_from_limbs(
+            &self,
+            ctx: &mut Self::Context,
+            limbs: &[impl Deref<Target = Self::AssignedScalar>],
+        ) -> Result<Self::AssignedEcPoint, plonk::Error>;
+
+        fn assign_ec_point_to_limbs(
+            &self,
+            ctx: &mut Self::Context,
+            ec_point: impl Deref<Target = Self::AssignedEcPoint>,
+        ) -> Result<Vec<Self::AssignedCell>, plonk::Error>;
     }
 
     impl<'a, C, PCS, EccChip, const LIMBS: usize, const BITS: usize>
@@ -177,41 +195,72 @@ mod halo2 {
             Rc<Halo2Loader<'a, C, EccChip>>,
             Accumulator = KzgAccumulator<C, Rc<Halo2Loader<'a, C, EccChip>>>,
         >,
-        EccChip: EccInstructions<
-            'a,
-            C,
-            AssignedEcPoint = AssignedPoint<<C as CurveAffine>::Base, C::Scalar, LIMBS, BITS>,
-            AssignedScalar = AssignedValue<C::Scalar>,
-        >,
+        EccChip: LimbsEncodingInstructions<'a, C, LIMBS, BITS>,
     {
         fn from_repr(limbs: &[&Scalar<'a, C, EccChip>]) -> Result<PCS::Accumulator, Error> {
             assert_eq!(limbs.len(), 4 * LIMBS);
 
             let loader = limbs[0].loader();
 
-            let assigned_limbs = limbs.iter().map(|limb| limb.assigned()).collect_vec();
-            let [lhs, rhs] = [&assigned_limbs[..2 * LIMBS], &assigned_limbs[2 * LIMBS..]].map(
-                |assigned_limbs| {
-                    let ec_point = ec_point_from_assigned_limbs::<_, LIMBS, BITS>(assigned_limbs);
-                    loader.assign_ec_point(ec_point)
-                },
-            );
-
-            for (src, dst) in assigned_limbs.iter().zip_eq(
-                iter::empty()
-                    .chain(lhs.assigned().x().limbs())
-                    .chain(lhs.assigned().y().limbs())
-                    .chain(rhs.assigned().x().limbs())
-                    .chain(rhs.assigned().y().limbs()),
-            ) {
-                loader
-                    .ctx_mut()
-                    .constrain_equal(src.cell(), dst.as_ref().cell())
+            let [lhs, rhs] = [&limbs[..2 * LIMBS], &limbs[2 * LIMBS..]].map(|limbs| {
+                let assigned = loader
+                    .ecc_chip()
+                    .assign_ec_point_from_limbs(
+                        &mut loader.ctx_mut(),
+                        &limbs.iter().map(|limb| limb.assigned()).collect_vec(),
+                    )
                     .unwrap();
-            }
-            let accumulator = KzgAccumulator::new(lhs, rhs);
+                loader.ec_point_from_assigned(assigned)
+            });
 
-            Ok(accumulator)
+            Ok(KzgAccumulator::new(lhs, rhs))
+        }
+    }
+
+    mod halo2_wrong {
+        use super::*;
+        use halo2_wrong_ecc::BaseFieldEccChip;
+
+        impl<'a, C: CurveAffine, const LIMBS: usize, const BITS: usize>
+            LimbsEncodingInstructions<'a, C, LIMBS, BITS> for BaseFieldEccChip<C, LIMBS, BITS>
+        {
+            fn assign_ec_point_from_limbs(
+                &self,
+                ctx: &mut Self::Context,
+                limbs: &[impl Deref<Target = Self::AssignedScalar>],
+            ) -> Result<Self::AssignedEcPoint, plonk::Error> {
+                assert_eq!(limbs.len(), 2 * LIMBS);
+
+                let ec_point = self.assign_point(
+                    ctx,
+                    ec_point_from_limbs::<_, LIMBS, BITS>(
+                        &limbs.iter().map(|limb| limb.value()).collect_vec(),
+                    ),
+                )?;
+
+                for (src, dst) in limbs.iter().zip_eq(
+                    iter::empty()
+                        .chain(ec_point.x().limbs())
+                        .chain(ec_point.y().limbs()),
+                ) {
+                    ctx.constrain_equal(src.cell(), dst.as_ref().cell())?;
+                }
+
+                Ok(ec_point)
+            }
+
+            fn assign_ec_point_to_limbs(
+                &self,
+                _: &mut Self::Context,
+                ec_point: impl Deref<Target = Self::AssignedEcPoint>,
+            ) -> Result<Vec<Self::AssignedCell>, plonk::Error> {
+                Ok(iter::empty()
+                    .chain(ec_point.x().limbs())
+                    .chain(ec_point.y().limbs())
+                    .map(|limb| limb.as_ref())
+                    .cloned()
+                    .collect())
+            }
         }
     }
 }

--- a/src/pcs/kzg/decider.rs
+++ b/src/pcs/kzg/decider.rs
@@ -144,7 +144,7 @@ mod evm {
 
                 let powers_of_challenge = LoadedScalar::<M::Scalar>::powers(&challenge, lhs.len());
                 let [lhs, rhs] = [lhs, rhs].map(|msms| {
-                    msms.into_iter()
+                    msms.iter()
                         .zip(powers_of_challenge.iter())
                         .map(|(msm, power_of_challenge)| {
                             Msm::<M::G1Affine, Rc<EvmLoader>>::base(msm) * power_of_challenge

--- a/src/system/halo2.rs
+++ b/src/system/halo2.rs
@@ -601,11 +601,14 @@ impl<'a, F: FieldExt> Polynomials<'a, F> {
                     .zip(permutation_fixeds.chunks(self.permutation_chunk_size))
                     .enumerate()
                     .map(
-                        |(i, ((((z, z_w, _), (_, z_next_w, _)), polys), permutation_fixeds))| {
+                        |(
+                            i,
+                            ((((z, z_omega, _), (_, z_next_omega, _)), polys), permutation_fixeds),
+                        )| {
                             let left = if self.zk || zs.len() == 1 {
-                                z_w.clone()
+                                z_omega.clone()
                             } else {
-                                z_w + l_last * (z_next_w - z_w)
+                                z_omega + l_last * (z_next_omega - z_omega)
                             } * polys
                                 .iter()
                                 .zip(permutation_fixeds.iter())
@@ -675,7 +678,10 @@ impl<'a, F: FieldExt> Polynomials<'a, F> {
             .iter()
             .zip(polys.iter())
             .flat_map(
-                |(lookup, (z, z_w, permuted_input, permuted_input_w_inv, permuted_table))| {
+                |(
+                    lookup,
+                    (z, z_omega, permuted_input, permuted_input_omega_inv, permuted_table),
+                )| {
                     let input = compress(lookup.input_expressions());
                     let table = compress(lookup.table_expressions());
                     iter::empty()
@@ -683,20 +689,20 @@ impl<'a, F: FieldExt> Polynomials<'a, F> {
                         .chain(self.zk.then(|| l_last * (z * z - z)))
                         .chain(Some(if self.zk {
                             l_active
-                                * (z_w * (permuted_input + beta) * (permuted_table + gamma)
+                                * (z_omega * (permuted_input + beta) * (permuted_table + gamma)
                                     - z * (input + beta) * (table + gamma))
                         } else {
-                            z_w * (permuted_input + beta) * (permuted_table + gamma)
+                            z_omega * (permuted_input + beta) * (permuted_table + gamma)
                                 - z * (input + beta) * (table + gamma)
                         }))
                         .chain(self.zk.then(|| l_0 * (permuted_input - permuted_table)))
                         .chain(Some(if self.zk {
                             l_active
                                 * (permuted_input - permuted_table)
-                                * (permuted_input - permuted_input_w_inv)
+                                * (permuted_input - permuted_input_omega_inv)
                         } else {
                             (permuted_input - permuted_table)
-                                * (permuted_input - permuted_input_w_inv)
+                                * (permuted_input - permuted_input_omega_inv)
                         }))
                 },
             )

--- a/src/system/halo2/test/kzg.rs
+++ b/src/system/halo2/test/kzg.rs
@@ -27,8 +27,8 @@ pub fn main_gate_with_range_with_mock_kzg_accumulator<M: MultiMillerLoop>(
     let srs = read_or_create_srs(TESTDATA_DIR, 1, setup::<M>);
     let [g1, s_g1] = [srs.get_g()[0], srs.get_g()[1]].map(|point| point.coordinates().unwrap());
     MainGateWithRange::new(
-        [*s_g1.x(), *s_g1.y(), *g1.x(), *g1.y()]
-            .iter()
+        [s_g1.x(), s_g1.y(), g1.x(), g1.y()]
+            .into_iter()
             .cloned()
             .flat_map(fe_to_limbs::<_, _, LIMBS, BITS>)
             .collect(),

--- a/src/system/halo2/test/kzg/halo2.rs
+++ b/src/system/halo2/test/kzg/halo2.rs
@@ -299,7 +299,7 @@ impl Circuit<Fr> for Accumulation {
                 loader.print_row_metering();
                 println!("Total row cost: {}", loader.ctx().offset());
 
-                Ok((lhs.assigned(), rhs.assigned()))
+                Ok((lhs.into_assigned(), rhs.into_assigned()))
             },
         )?;
 

--- a/src/util/arithmetic.rs
+++ b/src/util/arithmetic.rs
@@ -186,14 +186,14 @@ impl<T: FieldOps + Clone> Fraction<T> {
 
         self.eval = Some(
             self.numer
-                .as_ref()
-                .map(|numer| numer.clone() * &self.denom)
+                .take()
+                .map(|numer| numer * &self.denom)
                 .unwrap_or_else(|| self.denom.clone()),
         );
     }
 
     pub fn evaluated(&self) -> &T {
-        assert!(self.inv);
+        assert!(self.eval.is_some());
 
         self.eval.as_ref().unwrap()
     }

--- a/src/util/arithmetic.rs
+++ b/src/util/arithmetic.rs
@@ -241,19 +241,12 @@ pub fn fe_to_limbs<F1: PrimeField, F2: PrimeField, const LIMBS: usize, const BIT
     fe: F1,
 ) -> [F2; LIMBS] {
     let big = BigUint::from_bytes_le(fe.to_repr().as_ref());
-    let mask = (BigUint::one() << BITS) - 1usize;
+    let mask = &((BigUint::one() << BITS) - 1usize);
     (0usize..)
         .step_by(BITS)
         .take(LIMBS)
-        .map(move |shift| fe_from_big((&big >> shift) & &mask))
+        .map(|shift| fe_from_big((&big >> shift) & mask))
         .collect_vec()
         .try_into()
         .unwrap()
-}
-
-pub fn powers<F>(scalar: F) -> impl Iterator<Item = F>
-where
-    for<'a> F: Mul<&'a F, Output = F> + One + Clone,
-{
-    iter::successors(Some(F::one()), move |power| Some(scalar.clone() * power))
 }

--- a/src/util/protocol.rs
+++ b/src/util/protocol.rs
@@ -41,7 +41,7 @@ where
             quotient: self.quotient.clone(),
             transcript_initial_state,
             instance_committing_key: self.instance_committing_key.clone(),
-            linearization: self.linearization.clone(),
+            linearization: self.linearization,
             accumulator_indices: self.accumulator_indices.clone(),
         }
     }
@@ -82,11 +82,11 @@ where
         let langranges = langranges.into_iter().sorted().dedup().collect_vec();
 
         let one = loader.load_one();
-        let zn_minus_one = zn.clone() - one;
+        let zn_minus_one = zn.clone() - &one;
         let zn_minus_one_inv = Fraction::one_over(zn_minus_one.clone());
 
         let n_inv = loader.load_const(&domain.n_inv);
-        let numer = zn_minus_one.clone() * n_inv;
+        let numer = zn_minus_one.clone() * &n_inv;
         let omegas = langranges
             .iter()
             .map(|&i| loader.load_const(&domain.rotate_scalar(C::Scalar::one(), Rotation(i))))
@@ -378,7 +378,7 @@ fn merge_left_right<T: Ord>(a: Option<BTreeSet<T>>, b: Option<BTreeSet<T>>) -> O
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum LinearizationStrategy {
     /// Older linearization strategy of GWC19, which has linearization
     /// polynomial that doesn't evaluate to 0, and requires prover to send extra


### PR DESCRIPTION
- Simplify trait `EccInstructions`
- Reduce number of clones
- Generalize `AccumulatorEncoding` for `EccInstructions`
- Remove dev-dependency `foundry` and vendor only necessary part of it