### PR TITLE
Update `EvmLoader` to generate Yul code instead of bytecode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ num-integer = "0.1.45"
 num-traits = "0.2.15"
 rand = "0.8"
 hex = "0.4"
-regex = "1"
 halo2_curves = { git = "https://github.com/privacy-scaling-explorations/halo2curves", tag = "0.3.0", package = "halo2curves" }
 
 # parallel

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ num-integer = "0.1.45"
 num-traits = "0.2.15"
 rand = "0.8"
 hex = "0.4"
+regex = "1"
 halo2_curves = { git = "https://github.com/privacy-scaling-explorations/halo2curves", tag = "0.3.0", package = "halo2curves" }
 
 # parallel

--- a/examples/evm-verifier-with-accumulator.rs
+++ b/examples/evm-verifier-with-accumulator.rs
@@ -17,7 +17,7 @@ use halo2_proofs::{
 use itertools::Itertools;
 use plonk_verifier::{
     loader::{
-        evm::{encode_calldata, EvmLoader, ExecutorBuilder},
+        evm::{self, encode_calldata, EvmLoader, ExecutorBuilder},
         native::NativeLoader,
     },
     pcs::kzg::{Gwc19, Kzg, KzgAs, LimbsEncoding},
@@ -570,8 +570,7 @@ fn gen_aggregation_evm_verifier(
     let proof = Plonk::read_proof(&svk, &protocol, &instances, &mut transcript).unwrap();
     Plonk::verify(&svk, &dk, &protocol, &instances, &proof).unwrap();
 
-    let code = loader.yul_code();
-    loader.compile(&code)
+    evm::compile_yul(&loader.yul_code())
 }
 
 fn evm_verify(deployment_code: Vec<u8>, instances: Vec<Vec<Fr>>, proof: Vec<u8>) {

--- a/examples/evm-verifier-with-accumulator.rs
+++ b/examples/evm-verifier-with-accumulator.rs
@@ -570,7 +570,8 @@ fn gen_aggregation_evm_verifier(
     let proof = Plonk::read_proof(&svk, &protocol, &instances, &mut transcript).unwrap();
     Plonk::verify(&svk, &dk, &protocol, &instances, &proof).unwrap();
 
-    loader.deployment_code()
+    let code = loader.yul_code();
+    loader.compile(&code)
 }
 
 fn evm_verify(deployment_code: Vec<u8>, instances: Vec<Vec<Fr>>, proof: Vec<u8>) {

--- a/examples/evm-verifier.rs
+++ b/examples/evm-verifier.rs
@@ -222,7 +222,8 @@ fn gen_evm_verifier(
     let proof = Plonk::read_proof(&svk, &protocol, &instances, &mut transcript).unwrap();
     Plonk::verify(&svk, &dk, &protocol, &instances, &proof).unwrap();
 
-    loader.deployment_code()
+    let code = loader.yul_code();
+    loader.compile(&code)
 }
 
 fn evm_verify(deployment_code: Vec<u8>, instances: Vec<Vec<Fr>>, proof: Vec<u8>) {

--- a/examples/evm-verifier.rs
+++ b/examples/evm-verifier.rs
@@ -20,7 +20,7 @@ use halo2_proofs::{
 };
 use itertools::Itertools;
 use plonk_verifier::{
-    loader::evm::{encode_calldata, EvmLoader, ExecutorBuilder},
+    loader::evm::{self, encode_calldata, EvmLoader, ExecutorBuilder},
     pcs::kzg::{Gwc19, Kzg},
     system::halo2::{compile, transcript::evm::EvmTranscript, Config},
     verifier::{self, PlonkVerifier},
@@ -222,8 +222,7 @@ fn gen_evm_verifier(
     let proof = Plonk::read_proof(&svk, &protocol, &instances, &mut transcript).unwrap();
     Plonk::verify(&svk, &dk, &protocol, &instances, &proof).unwrap();
 
-    let code = loader.yul_code();
-    loader.compile(&code)
+    evm::compile_yul(&loader.yul_code())
 }
 
 fn evm_verify(deployment_code: Vec<u8>, instances: Vec<Vec<Fr>>, proof: Vec<u8>) {

--- a/src/loader/evm.rs
+++ b/src/loader/evm.rs
@@ -7,7 +7,8 @@ mod test;
 
 pub use loader::{EcPoint, EvmLoader, Scalar};
 pub use util::{
-    encode_calldata, estimate_gas, fe_to_u256, modulus, u256_to_fe, ExecutorBuilder, MemoryChunk,
+    compile_yul, encode_calldata, estimate_gas, fe_to_u256, modulus, u256_to_fe, ExecutorBuilder,
+    MemoryChunk,
 };
 
 pub use ethereum_types::U256;

--- a/src/loader/evm/code.rs
+++ b/src/loader/evm/code.rs
@@ -1,7 +1,3 @@
-use crate::util::Itertools;
-use ethereum_types::U256;
-use std::{collections::HashMap, iter};
-
 pub enum Precompiled {
     BigModExp = 0x05,
     Bn254Add = 0x6,
@@ -10,286 +6,70 @@ pub enum Precompiled {
 }
 
 #[derive(Clone, Debug)]
-pub struct Code {
-    code: Vec<u8>,
-    constants: HashMap<U256, usize>,
-    stack_len: usize,
+pub struct YulCode {
+    // runtime code area
+    runtime: String,
 }
 
-impl Code {
-    pub fn new(constants: impl IntoIterator<Item = U256>) -> Self {
-        let mut code = Self {
-            code: Vec::new(),
-            constants: HashMap::new(),
-            stack_len: 0,
-        };
-        let constants = constants.into_iter().collect_vec();
-        for constant in constants.iter() {
-            code.push(*constant);
+impl YulCode {
+    pub fn new() -> Self {
+        YulCode {
+            runtime: String::new(),
         }
-        code.constants = HashMap::from_iter(
-            constants
-                .into_iter()
-                .enumerate()
-                .map(|(idx, value)| (value, idx)),
-        );
-        code
     }
 
-    pub fn deployment(code: Vec<u8>) -> Vec<u8> {
-        let code_len = code.len();
-        assert_ne!(code_len, 0);
-
-        iter::empty()
-            .chain([
-                PUSH1 + 1,
-                (code_len >> 8) as u8,
-                (code_len & 0xff) as u8,
-                PUSH1,
-                14,
-                PUSH1,
-                0,
-                CODECOPY,
-            ])
-            .chain([
-                PUSH1 + 1,
-                (code_len >> 8) as u8,
-                (code_len & 0xff) as u8,
-                PUSH1,
-                0,
-                RETURN,
-            ])
-            .chain(code)
-            .collect()
+    pub fn code(&self, base_modulus: String, scalar_modulus: String) -> String {
+        format!(
+            "
+        object \"plonk_verifier\" {{
+            code {{
+                function allocate(size) -> ptr {{
+                    ptr := mload(0x40)
+                    if eq(ptr, 0) {{ ptr := 0x60 }}
+                    mstore(0x40, add(ptr, size))
+                }}
+                let size := datasize(\"Runtime\")
+                let offset := allocate(size)
+                datacopy(offset, dataoffset(\"Runtime\"), size)
+                return(offset, size)
+            }}
+            object \"Runtime\" {{
+                code {{
+                    let success:bool := true
+                    let f_p := {base_modulus}
+                    let f_q := {scalar_modulus}
+                    function validate_ec_point(x, y) -> valid:bool {{
+                        {{
+                            let x_lt_p:bool := lt(x, {base_modulus})
+                            let y_lt_p:bool := lt(y, {base_modulus})
+                            valid := and(x_lt_p, y_lt_p)
+                        }}
+                        {{
+                            let x_is_zero:bool := eq(x, 0)
+                            let y_is_zero:bool := eq(y, 0)
+                            let x_or_y_is_zero:bool := or(x_is_zero, y_is_zero)
+                            let x_and_y_is_not_zero:bool := not(x_or_y_is_zero)
+                            valid := and(x_and_y_is_not_zero, valid)
+                        }}
+                        {{
+                            let y_square := mulmod(y, y, {base_modulus})
+                            let x_square := mulmod(x, x, {base_modulus})
+                            let x_cube := mulmod(x_square, x, {base_modulus})
+                            let x_cube_plus_3 := addmod(x_cube, 3, {base_modulus})
+                            let y_square_eq_x_cube_plus_3:bool := eq(x_cube_plus_3, y_square)
+                            valid := and(y_square_eq_x_cube_plus_3, valid)
+                        }}
+                    }}
+                    {}
+                }}
+            }}
+        }}",
+            self.runtime
+        )
     }
 
-    pub fn stack_len(&self) -> usize {
-        self.stack_len
-    }
-
-    pub fn len(&self) -> usize {
-        self.code.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.code.is_empty()
-    }
-
-    pub fn push<T: Into<U256>>(&mut self, value: T) -> &mut Self {
-        let value = value.into();
-        match self.constants.get(&value) {
-            Some(idx) if (0..16).contains(&(self.stack_len - idx - 1)) => {
-                self.dup(self.stack_len - idx - 1);
-            }
-            _ => {
-                let mut bytes = vec![0; 32];
-                value.to_big_endian(&mut bytes);
-                let bytes = bytes
-                    .iter()
-                    .position(|byte| *byte != 0)
-                    .map_or(vec![0], |pos| bytes.drain(pos..).collect());
-                self.code.push(PUSH1 - 1 + bytes.len() as u8);
-                self.code.extend(bytes);
-                self.stack_len += 1;
-            }
-        }
-        self
-    }
-
-    pub fn dup(&mut self, pos: usize) -> &mut Self {
-        assert!((0..16).contains(&pos));
-        self.code.push(DUP1 + pos as u8);
-        self.stack_len += 1;
-        self
-    }
-
-    pub fn swap(&mut self, pos: usize) -> &mut Self {
-        assert!((1..17).contains(&pos));
-        self.code.push(SWAP1 - 1 + pos as u8);
-        self
+    pub fn runtime_append(&mut self, mut code: String) {
+        code.push('\n');
+        self.runtime.push_str(&code);
     }
 }
-
-impl From<Code> for Vec<u8> {
-    fn from(code: Code) -> Self {
-        code.code
-    }
-}
-
-macro_rules! impl_opcodes {
-    ($($method:ident -> ($opcode:ident, $stack_len_diff:expr))*) => {
-        $(
-            #[allow(dead_code)]
-            impl Code {
-                pub fn $method(&mut self) -> &mut Self {
-                    self.code.push($opcode);
-                    self.stack_len = ((self.stack_len as isize) + $stack_len_diff) as usize;
-                    self
-                }
-            }
-        )*
-    };
-}
-
-impl_opcodes!(
-    stop -> (STOP, 0)
-    add -> (ADD, -1)
-    mul -> (MUL, -1)
-    sub -> (SUB, -1)
-    div -> (DIV, -1)
-    sdiv -> (SDIV, -1)
-    r#mod -> (MOD, -1)
-    smod -> (SMOD, -1)
-    addmod -> (ADDMOD, -2)
-    mulmod -> (MULMOD, -2)
-    exp -> (EXP, -1)
-    signextend -> (SIGNEXTEND, -1)
-    lt -> (LT, -1)
-    gt -> (GT, -1)
-    slt -> (SLT, -1)
-    sgt -> (SGT, -1)
-    eq -> (EQ, -1)
-    iszero -> (ISZERO, 0)
-    and -> (AND, -1)
-    or -> (OR, -1)
-    xor -> (XOR, -1)
-    not -> (NOT, 0)
-    byte -> (BYTE, -1)
-    shl -> (SHL, -1)
-    shr -> (SHR, -1)
-    sar -> (SAR, -1)
-    keccak256 -> (SHA3, -1)
-    address -> (ADDRESS, 1)
-    balance -> (BALANCE, 0)
-    origin -> (ORIGIN, 1)
-    caller -> (CALLER, 1)
-    callvalue -> (CALLVALUE, 1)
-    calldataload -> (CALLDATALOAD, 0)
-    calldatasize -> (CALLDATASIZE, 1)
-    calldatacopy -> (CALLDATACOPY, -3)
-    codesize -> (CODESIZE, 1)
-    codecopy -> (CODECOPY, -3)
-    gasprice -> (GASPRICE, 1)
-    extcodesize -> (EXTCODESIZE, 0)
-    extcodecopy -> (EXTCODECOPY, -4)
-    returndatasize -> (RETURNDATASIZE, 1)
-    returndatacopy -> (RETURNDATACOPY, -3)
-    extcodehash -> (EXTCODEHASH, 0)
-    blockhash -> (BLOCKHASH, 0)
-    coinbase -> (COINBASE, 1)
-    timestamp -> (TIMESTAMP, 1)
-    number -> (NUMBER, 1)
-    difficulty -> (DIFFICULTY, 1)
-    gaslimit -> (GASLIMIT, 1)
-    chainid -> (CHAINID, 1)
-    selfbalance -> (SELFBALANCE, 1)
-    basefee -> (BASEFEE, 1)
-    pop -> (POP, -1)
-    mload -> (MLOAD, 0)
-    mstore -> (MSTORE, -2)
-    mstore8 -> (MSTORE8, -2)
-    sload -> (SLOAD, 0)
-    sstore -> (SSTORE, -2)
-    jump -> (JUMP, -1)
-    jumpi -> (JUMPI, -2)
-    pc -> (PC, 1)
-    msize -> (MSIZE, 1)
-    gas -> (GAS, 1)
-    jumpdest -> (JUMPDEST, 0)
-    log0 -> (LOG0, -2)
-    log1 -> (LOG1, -3)
-    log2 -> (LOG2, -4)
-    log3 -> (LOG3, -5)
-    log4 -> (LOG4, -6)
-    create -> (CREATE, -2)
-    call -> (CALL, -6)
-    callcode -> (CALLCODE, -6)
-    r#return -> (RETURN, -2)
-    delegatecall -> (DELEGATECALL, -5)
-    create2 -> (CREATE2, -3)
-    staticcall -> (STATICCALL, -5)
-    revert -> (REVERT, -2)
-    selfdestruct -> (SELFDESTRUCT, -1)
-);
-
-const STOP: u8 = 0x00;
-const ADD: u8 = 0x01;
-const MUL: u8 = 0x02;
-const SUB: u8 = 0x03;
-const DIV: u8 = 0x04;
-const SDIV: u8 = 0x05;
-const MOD: u8 = 0x06;
-const SMOD: u8 = 0x07;
-const ADDMOD: u8 = 0x08;
-const MULMOD: u8 = 0x09;
-const EXP: u8 = 0x0A;
-const SIGNEXTEND: u8 = 0x0B;
-const LT: u8 = 0x10;
-const GT: u8 = 0x11;
-const SLT: u8 = 0x12;
-const SGT: u8 = 0x13;
-const EQ: u8 = 0x14;
-const ISZERO: u8 = 0x15;
-const AND: u8 = 0x16;
-const OR: u8 = 0x17;
-const XOR: u8 = 0x18;
-const NOT: u8 = 0x19;
-const BYTE: u8 = 0x1A;
-const SHL: u8 = 0x1B;
-const SHR: u8 = 0x1C;
-const SAR: u8 = 0x1D;
-const SHA3: u8 = 0x20;
-const ADDRESS: u8 = 0x30;
-const BALANCE: u8 = 0x31;
-const ORIGIN: u8 = 0x32;
-const CALLER: u8 = 0x33;
-const CALLVALUE: u8 = 0x34;
-const CALLDATALOAD: u8 = 0x35;
-const CALLDATASIZE: u8 = 0x36;
-const CALLDATACOPY: u8 = 0x37;
-const CODESIZE: u8 = 0x38;
-const CODECOPY: u8 = 0x39;
-const GASPRICE: u8 = 0x3A;
-const EXTCODESIZE: u8 = 0x3B;
-const EXTCODECOPY: u8 = 0x3C;
-const RETURNDATASIZE: u8 = 0x3D;
-const RETURNDATACOPY: u8 = 0x3E;
-const EXTCODEHASH: u8 = 0x3F;
-const BLOCKHASH: u8 = 0x40;
-const COINBASE: u8 = 0x41;
-const TIMESTAMP: u8 = 0x42;
-const NUMBER: u8 = 0x43;
-const DIFFICULTY: u8 = 0x44;
-const GASLIMIT: u8 = 0x45;
-const CHAINID: u8 = 0x46;
-const SELFBALANCE: u8 = 0x47;
-const BASEFEE: u8 = 0x48;
-const POP: u8 = 0x50;
-const MLOAD: u8 = 0x51;
-const MSTORE: u8 = 0x52;
-const MSTORE8: u8 = 0x53;
-const SLOAD: u8 = 0x54;
-const SSTORE: u8 = 0x55;
-const JUMP: u8 = 0x56;
-const JUMPI: u8 = 0x57;
-const PC: u8 = 0x58;
-const MSIZE: u8 = 0x59;
-const GAS: u8 = 0x5A;
-const JUMPDEST: u8 = 0x5B;
-const PUSH1: u8 = 0x60;
-const DUP1: u8 = 0x80;
-const SWAP1: u8 = 0x90;
-const LOG0: u8 = 0xA0;
-const LOG1: u8 = 0xA1;
-const LOG2: u8 = 0xA2;
-const LOG3: u8 = 0xA3;
-const LOG4: u8 = 0xA4;
-const CREATE: u8 = 0xF0;
-const CALL: u8 = 0xF1;
-const CALLCODE: u8 = 0xF2;
-const RETURN: u8 = 0xF3;
-const DELEGATECALL: u8 = 0xF4;
-const CREATE2: u8 = 0xF5;
-const STATICCALL: u8 = 0xFA;
-const REVERT: u8 = 0xFD;
-const SELFDESTRUCT: u8 = 0xFF;

--- a/src/loader/evm/loader.rs
+++ b/src/loader/evm/loader.rs
@@ -440,7 +440,13 @@ impl EvmLoader {
         self.code.borrow_mut().runtime_append(code);
     }
 
-    fn end_gas_metering(self: &Rc<Self>) {}
+    fn end_gas_metering(self: &Rc<Self>) {
+        let code = format!(
+            "log1(0, 0, sub({}, gas()))",
+            self.gas_metering_ids.borrow().last().unwrap()
+        );
+        self.code.borrow_mut().runtime_append(code);
+    }
 
     pub fn print_gas_metering(self: &Rc<Self>, costs: Vec<u64>) {
         for (identifier, cost) in self.gas_metering_ids.borrow().iter().zip(costs) {

--- a/src/loader/evm/loader.rs
+++ b/src/loader/evm/loader.rs
@@ -1,9 +1,11 @@
 use crate::{
-    loader::evm::{
-        code::{Code, Precompiled},
-        fe_to_u256, modulus,
+    loader::{
+        evm::{
+            code::{Precompiled, YulCode},
+            fe_to_u256, modulus, u256_to_fe,
+        },
+        EcPointLoader, LoadedEcPoint, LoadedScalar, Loader, ScalarLoader,
     },
-    loader::{evm::u256_to_fe, EcPointLoader, LoadedEcPoint, LoadedScalar, Loader, ScalarLoader},
     util::{
         arithmetic::{CurveAffine, FieldOps, PrimeField},
         Itertools,
@@ -11,12 +13,15 @@ use crate::{
     Error,
 };
 use ethereum_types::{U256, U512};
+use hex;
+use regex::Regex;
 use std::{
     cell::RefCell,
     collections::HashMap,
     fmt::{self, Debug},
     iter,
     ops::{Add, AddAssign, DerefMut, Mul, MulAssign, Neg, Sub, SubAssign},
+    process::Command,
     rc::Rc,
 };
 
@@ -50,24 +55,29 @@ impl<T: Debug> Value<T> {
 pub struct EvmLoader {
     base_modulus: U256,
     scalar_modulus: U256,
-    code: RefCell<Code>,
+    code: RefCell<YulCode>,
     ptr: RefCell<usize>,
     cache: RefCell<HashMap<String, usize>>,
     #[cfg(test)]
     gas_metering_ids: RefCell<Vec<String>>,
 }
 
+fn hex_encode_u256(value: &U256) -> String {
+    let mut bytes = [0; 32];
+    value.to_big_endian(&mut bytes);
+    format!("0x{}", hex::encode(bytes))
+}
+
 impl EvmLoader {
     pub fn new<Base, Scalar>() -> Rc<Self>
     where
-        Base: PrimeField<Repr = [u8; 32]>,
+        Base: PrimeField<Repr = [u8; 0x20]>,
         Scalar: PrimeField<Repr = [u8; 32]>,
     {
         let base_modulus = modulus::<Base>();
         let scalar_modulus = modulus::<Scalar>();
-        let code = Code::new([1.into(), base_modulus, scalar_modulus - 1, scalar_modulus])
-            .push(1)
-            .to_owned();
+        let code = YulCode::new();
+
         Rc::new(Self {
             base_modulus,
             scalar_modulus,
@@ -79,22 +89,59 @@ impl EvmLoader {
         })
     }
 
-    pub fn deployment_code(self: &Rc<Self>) -> Vec<u8> {
-        Code::deployment(self.runtime_code())
+    pub fn yul_code(self: &Rc<Self>) -> String {
+        let code = "
+            if not(success) { revert(0, 0) }
+            return(0, 0)"
+            .to_string();
+        self.code.borrow_mut().runtime_append(code);
+        self.code.borrow().code(
+            hex_encode_u256(&self.base_modulus),
+            hex_encode_u256(&self.scalar_modulus),
+        )
     }
 
-    pub fn runtime_code(self: &Rc<Self>) -> Vec<u8> {
-        let mut code = self.code.borrow().clone();
-        let dst = code.len() + 9;
-        code.push(dst)
-            .jumpi()
-            .push(0)
-            .push(0)
-            .revert()
-            .jumpdest()
-            .stop()
-            .to_owned()
-            .into()
+    // Generates Yul verifier in the current working directory.
+    // Panics when the invalid Yul code is generated.
+    pub fn compile(self: &Rc<Self>, code: &str) -> Vec<u8> {
+        let mut cmd = Command::new("solc");
+
+        use std::io::Write;
+        let mut file = std::fs::File::create("./evm-verifier.yul").unwrap();
+        write!(&mut file, "{}", code).unwrap();
+        let output = cmd
+            .arg("--bin")
+            .arg("--yul")
+            .arg("./evm-verifier.yul")
+            .output()
+            .expect("failed to execute process")
+            .stdout;
+        let output = String::from_utf8(output).unwrap();
+        let re = Regex::new(r"([\da-fA-F]{2})").unwrap();
+        let mut hex_string = String::new();
+        for hex in re.find_iter(&output) {
+            hex_string.push_str(hex.as_str());
+        }
+
+        fn hex_to_bytes(s: &str) -> Option<Vec<u8>> {
+            if s.len() % 2 == 0 {
+                (0..s.len())
+                    .step_by(2)
+                    .map(|i| {
+                        s.get(i..i + 2)
+                            .and_then(|sub| u8::from_str_radix(sub, 16).ok())
+                    })
+                    .collect()
+            } else {
+                None
+            }
+        }
+
+        let bytecode = hex_to_bytes(&hex_string).unwrap();
+        if bytecode.is_empty() {
+            panic!("Failed to compile Yul verifier.");
+        }
+        bytecode
     }
 
     pub fn allocate(self: &Rc<Self>, size: usize) -> usize {
@@ -103,16 +150,108 @@ impl EvmLoader {
         ptr
     }
 
-    pub(crate) fn scalar_modulus(&self) -> U256 {
-        self.scalar_modulus
-    }
-
     pub(crate) fn ptr(&self) -> usize {
         *self.ptr.borrow()
     }
 
-    pub(crate) fn code_mut(&self) -> impl DerefMut<Target = Code> + '_ {
+    pub(crate) fn code_mut(&self) -> impl DerefMut<Target = YulCode> + '_ {
         self.code.borrow_mut()
+    }
+
+    fn push(self: &Rc<Self>, scalar: &Scalar) -> String {
+        match scalar.value.clone() {
+            Value::Constant(constant) => {
+                format!("{constant}")
+            }
+            Value::Memory(ptr) => {
+                format!("mload({ptr:#x})")
+            }
+            Value::Negated(value) => {
+                let v = self.push(&self.scalar(*value));
+                format!("sub(f_q, {v})")
+            }
+            Value::Sum(lhs, rhs) => {
+                let lhs = self.push(&self.scalar(*lhs));
+                let rhs = self.push(&self.scalar(*rhs));
+                format!("addmod({lhs}, {rhs}, f_q)")
+            }
+            Value::Product(lhs, rhs) => {
+                let lhs = self.push(&self.scalar(*lhs));
+                let rhs = self.push(&self.scalar(*rhs));
+                format!("mulmod({lhs}, {rhs}, f_q)")
+            }
+        }
+    }
+
+    pub fn calldataload_scalar(self: &Rc<Self>, offset: usize) -> Scalar {
+        let ptr = self.allocate(0x20);
+        let code = format!("mstore({ptr:#x}, mod(calldataload({offset:#x}), f_q))");
+        self.code.borrow_mut().runtime_append(code);
+        self.scalar(Value::Memory(ptr))
+    }
+
+    pub fn calldataload_ec_point(self: &Rc<Self>, offset: usize) -> EcPoint {
+        let x_ptr = self.allocate(0x40);
+        let y_ptr = x_ptr + 0x20;
+        let x_cd_ptr = offset;
+        let y_cd_ptr = offset + 0x20;
+        let validate_code = self.validate_ec_point();
+        let code = format!(
+            "
+        {{
+            let x := calldataload({x_cd_ptr:#x})
+            mstore({x_ptr:#x}, x)
+            let y := calldataload({y_cd_ptr:#x})
+            mstore({y_ptr:#x}, y)
+            {validate_code}
+        }}"
+        );
+        self.code.borrow_mut().runtime_append(code);
+        self.ec_point(Value::Memory(x_ptr))
+    }
+
+    pub fn ec_point_from_limbs<const LIMBS: usize, const BITS: usize>(
+        self: &Rc<Self>,
+        x_limbs: [&Scalar; LIMBS],
+        y_limbs: [&Scalar; LIMBS],
+    ) -> EcPoint {
+        let ptr = self.allocate(0x40);
+        let mut code = String::new();
+        for (idx, limb) in x_limbs.iter().enumerate() {
+            let limb_i = self.push(limb);
+            let shift = idx * BITS;
+            if idx == 0 {
+                code.push_str(format!("let x := {limb_i}\n").as_str());
+            } else {
+                code.push_str(format!("x := add(x, shl({shift}, {limb_i}))\n").as_str());
+            }
+        }
+        let x_ptr = ptr;
+        code.push_str(format!("mstore({x_ptr}, x)\n").as_str());
+        for (idx, limb) in y_limbs.iter().enumerate() {
+            let limb_i = self.push(limb);
+            let shift = idx * BITS;
+            if idx == 0 {
+                code.push_str(format!("let y := {limb_i}\n").as_str());
+            } else {
+                code.push_str(format!("y := add(y, shl({shift}, {limb_i}))\n").as_str());
+            }
+        }
+        let y_ptr = ptr + 0x20;
+        code.push_str(format!("mstore({y_ptr}, y)\n").as_str());
+        let validate_code = self.validate_ec_point();
+        let code = format!(
+            "{{
+            {code}
+            {validate_code}
+        }}"
+        );
+        self.code.borrow_mut().runtime_append(code);
+        self.ec_point(Value::Memory(ptr))
+    }
+
+    fn validate_ec_point(self: &Rc<Self>) -> String {
+        "success := and(validate_ec_point(x, y), success)".to_string()
     }
 
     pub(crate) fn scalar(self: &Rc<Self>, value: Value<U256>) -> Scalar {
@@ -127,12 +266,14 @@ impl EvmLoader {
             let ptr = if let Some(ptr) = some_ptr {
                 ptr
             } else {
-                self.push(&Scalar {
+                let v = self.push(&Scalar {
                     loader: self.clone(),
                     value,
                 });
                 let ptr = self.allocate(0x20);
-                self.code.borrow_mut().push(ptr).mstore();
+                self.code
+                    .borrow_mut()
+                    .runtime_append(format!("mstore({ptr:#x}, {v})"));
                 self.cache.borrow_mut().insert(identifier, ptr);
                 ptr
             };
@@ -151,199 +292,18 @@ impl EvmLoader {
         }
     }
 
-    fn push(self: &Rc<Self>, scalar: &Scalar) {
-        match scalar.value.clone() {
-            Value::Constant(constant) => {
-                self.code.borrow_mut().push(constant);
-            }
-            Value::Memory(ptr) => {
-                self.code.borrow_mut().push(ptr).mload();
-            }
-            Value::Negated(value) => {
-                self.push(&self.scalar(*value));
-                self.code.borrow_mut().push(self.scalar_modulus).sub();
-            }
-            Value::Sum(lhs, rhs) => {
-                self.code.borrow_mut().push(self.scalar_modulus);
-                self.push(&self.scalar(*lhs));
-                self.push(&self.scalar(*rhs));
-                self.code.borrow_mut().addmod();
-            }
-            Value::Product(lhs, rhs) => {
-                self.code.borrow_mut().push(self.scalar_modulus);
-                self.push(&self.scalar(*lhs));
-                self.push(&self.scalar(*rhs));
-                self.code.borrow_mut().mulmod();
-            }
-        }
-    }
-
-    pub fn calldataload_scalar(self: &Rc<Self>, offset: usize) -> Scalar {
-        let ptr = self.allocate(0x20);
-        self.code
-            .borrow_mut()
-            .push(self.scalar_modulus)
-            .push(offset)
-            .calldataload()
-            .r#mod()
-            .push(ptr)
-            .mstore();
-        self.scalar(Value::Memory(ptr))
-    }
-
-    pub fn calldataload_ec_point(self: &Rc<Self>, offset: usize) -> EcPoint {
-        let ptr = self.allocate(0x40);
-        self.code
-            .borrow_mut()
-            // [..., success]
-            .push(offset)
-            // [..., success, x_cd_ptr]
-            .calldataload()
-            // [..., success, x]
-            .dup(0)
-            // [..., success, x, x]
-            .push(ptr)
-            // [..., success, x, x, x_ptr]
-            .mstore()
-            // [..., success, x]
-            .push(offset + 0x20)
-            // [..., success, x, y_cd_ptr]
-            .calldataload()
-            // [..., success, x, y]
-            .dup(0)
-            // [..., success, x, y, y]
-            .push(ptr + 0x20)
-            // [..., success, x, y, y, y_ptr]
-            .mstore();
-        // [..., success, x, y]
-        self.validate_ec_point();
-        self.ec_point(Value::Memory(ptr))
-    }
-
-    pub fn ec_point_from_limbs<const LIMBS: usize, const BITS: usize>(
-        self: &Rc<Self>,
-        x_limbs: [&Scalar; LIMBS],
-        y_limbs: [&Scalar; LIMBS],
-    ) -> EcPoint {
-        let ptr = self.allocate(0x40);
-        for (ptr, limbs) in [(ptr, x_limbs), (ptr + 0x20, y_limbs)] {
-            for (idx, limb) in limbs.into_iter().enumerate() {
-                self.push(limb);
-                // [..., success, acc]
-                if idx > 0 {
-                    self.code
-                        .borrow_mut()
-                        .push(idx * BITS)
-                        // [..., success, acc, limb_i, shift]
-                        .shl()
-                        // [..., success, acc, limb_i << shift]
-                        .add();
-                    // [..., success, acc]
-                }
-            }
-            self.code
-                .borrow_mut()
-                // [..., success, coordinate]
-                .dup(0)
-                // [..., success, coordinate, coordinate]
-                .push(ptr)
-                // [..., success, coordinate, coordinate, ptr]
-                .mstore();
-            // [..., success, coordinate]
-        }
-        // [..., success, x, y]
-        self.validate_ec_point();
-        self.ec_point(Value::Memory(ptr))
-    }
-
-    fn validate_ec_point(self: &Rc<Self>) {
-        self.code
-            .borrow_mut()
-            // [..., success, x, y]
-            .push(self.base_modulus)
-            // [..., success, x, y, p]
-            .dup(2)
-            // [..., success, x, y, p, x]
-            .lt()
-            // [..., success, x, y, x_lt_p]
-            .push(self.base_modulus)
-            // [..., success, x, y, x_lt_p, p]
-            .dup(2)
-            // [..., success, x, y, x_lt_p, p, y]
-            .lt()
-            // [..., success, x, y, x_lt_p, y_lt_p]
-            .and()
-            // [..., success, x, y, valid]
-            .dup(2)
-            // [..., success, x, y, valid, x]
-            .iszero()
-            // [..., success, x, y, valid, x_is_zero]
-            .dup(2)
-            // [..., success, x, y, valid, x_is_zero, y]
-            .iszero()
-            // [..., success, x, y, valid, x_is_zero, y_is_zero]
-            .or()
-            // [..., success, x, y, valid, x_or_y_is_zero]
-            .not()
-            // [..., success, x, y, valid, x_and_y_is_not_zero]
-            .and()
-            // [..., success, x, y, valid]
-            .push(self.base_modulus)
-            // [..., success, x, y, valid, p]
-            .dup(2)
-            // [..., success, x, y, valid, p, y]
-            .dup(0)
-            // [..., success, x, y, valid, p, y, y]
-            .mulmod()
-            // [..., success, x, y, valid, y_square]
-            .push(self.base_modulus)
-            // [..., success, x, y, valid, y_square, p]
-            .push(3)
-            // [..., success, x, y, valid, y_square, p, 3]
-            .push(self.base_modulus)
-            // [..., success, x, y, valid, y_square, p, 3, p]
-            .dup(6)
-            // [..., success, x, y, valid, y_square, p, 3, p, x]
-            .push(self.base_modulus)
-            // [..., success, x, y, valid, y_square, p, 3, p, x, p]
-            .dup(1)
-            // [..., success, x, y, valid, y_square, p, 3, p, x, p, x]
-            .dup(0)
-            // [..., success, x, y, valid, y_square, p, 3, p, x, p, x, x]
-            .mulmod()
-            // [..., success, x, y, valid, y_square, p, 3, p, x, x_square]
-            .mulmod()
-            // [..., success, x, y, valid, y_square, p, 3, x_cube]
-            .addmod()
-            // [..., success, x, y, valid, y_square, x_cube_plus_3]
-            .eq()
-            // [..., success, x, y, valid, y_square_eq_x_cube_plus_3]
-            .and()
-            // [..., success, x, y, valid]
-            .swap(2)
-            // [..., success, valid, y, x]
-            .pop()
-            // [..., success, valid, y]
-            .pop()
-            // [..., success, valid]
-            .and();
-    }
-
     pub fn keccak256(self: &Rc<Self>, ptr: usize, len: usize) -> usize {
         let hash_ptr = self.allocate(0x20);
-        self.code
-            .borrow_mut()
-            .push(len)
-            .push(ptr)
-            .keccak256()
-            .push(hash_ptr)
-            .mstore();
+        let code = format!("mstore({hash_ptr:#x}, keccak256({ptr:#x}, {len}))");
+        self.code.borrow_mut().runtime_append(code);
         hash_ptr
     }
 
     pub fn copy_scalar(self: &Rc<Self>, scalar: &Scalar, ptr: usize) {
-        self.push(scalar);
-        self.code.borrow_mut().push(ptr).mstore();
+        let scalar = self.push(scalar);
+        self.code
+            .borrow_mut()
+            .runtime_append(format!("mstore({ptr:#x}, {scalar})"));
     }
 
     pub fn dup_scalar(self: &Rc<Self>, scalar: &Scalar) -> Scalar {
@@ -356,26 +316,26 @@ impl EvmLoader {
         let ptr = self.allocate(0x40);
         match value.value {
             Value::Constant((x, y)) => {
-                self.code
-                    .borrow_mut()
-                    .push(x)
-                    .push(ptr)
-                    .mstore()
-                    .push(y)
-                    .push(ptr + 0x20)
-                    .mstore();
+                let x_ptr = ptr;
+                let y_ptr = ptr + 0x20;
+                let x = hex_encode_u256(&x);
+                let y = hex_encode_u256(&y);
+                let code = format!(
+                    "mstore({x_ptr:#x}, {x})
+                    mstore({y_ptr:#x}, {y})"
+                );
+                self.code.borrow_mut().runtime_append(code);
             }
             Value::Memory(src_ptr) => {
-                self.code
-                    .borrow_mut()
-                    .push(src_ptr)
-                    .mload()
-                    .push(ptr)
-                    .mstore()
-                    .push(src_ptr + 0x20)
-                    .mload()
-                    .push(ptr + 0x20)
-                    .mstore();
+                let x_ptr = ptr;
+                let y_ptr = ptr + 0x20;
+                let src_x = src_ptr;
+                let src_y = src_ptr + 0x20;
+                let code = format!(
+                    "mstore({x_ptr:#x}, mload({src_x:#x}))
+                    mstore({y_ptr:#x}, mload({src_y:#x}))"
+                );
+                self.code.borrow_mut().runtime_append(code);
             }
             Value::Negated(_) | Value::Sum(_, _) | Value::Product(_, _) => {
                 unreachable!()
@@ -391,16 +351,9 @@ impl EvmLoader {
             Precompiled::Bn254ScalarMul => (0x60, 0x40),
             Precompiled::Bn254Pairing => (0x180, 0x20),
         };
-        self.code
-            .borrow_mut()
-            .push(rd_len)
-            .push(rd_ptr)
-            .push(cd_len)
-            .push(cd_ptr)
-            .push(precompile as usize)
-            .gas()
-            .staticcall()
-            .and();
+        let a = precompile as usize;
+        let code = format!("success := and(eq(staticcall(gas(), {a:#x}, {cd_ptr:#x}, {cd_len:#x}, {rd_ptr:#x}, {rd_len:#x}), 1), success)");
+        self.code.borrow_mut().runtime_append(code);
     }
 
     fn invert(self: &Rc<Self>, scalar: &Scalar) -> Scalar {
@@ -441,38 +394,41 @@ impl EvmLoader {
     ) {
         let rd_ptr = self.dup_ec_point(lhs).ptr();
         self.allocate(0x80);
-        self.code
-            .borrow_mut()
-            .push(g2.0)
-            .push(rd_ptr + 0x40)
-            .mstore()
-            .push(g2.1)
-            .push(rd_ptr + 0x60)
-            .mstore()
-            .push(g2.2)
-            .push(rd_ptr + 0x80)
-            .mstore()
-            .push(g2.3)
-            .push(rd_ptr + 0xa0)
-            .mstore();
+        let g2_0 = hex_encode_u256(&g2.0);
+        let g2_0_ptr = rd_ptr + 0x40;
+        let g2_1 = hex_encode_u256(&g2.1);
+        let g2_1_ptr = rd_ptr + 0x60;
+        let g2_2 = hex_encode_u256(&g2.2);
+        let g2_2_ptr = rd_ptr + 0x80;
+        let g2_3 = hex_encode_u256(&g2.3);
+        let g2_3_ptr = rd_ptr + 0xa0;
+        let code = format!(
+            "mstore({g2_0_ptr:#x}, {g2_0})
+            mstore({g2_1_ptr:#x}, {g2_1})
+            mstore({g2_2_ptr:#x}, {g2_2})
+            mstore({g2_3_ptr:#x}, {g2_3})"
+        );
+        self.code.borrow_mut().runtime_append(code);
         self.dup_ec_point(rhs);
         self.allocate(0x80);
-        self.code
-            .borrow_mut()
-            .push(minus_s_g2.0)
-            .push(rd_ptr + 0x100)
-            .mstore()
-            .push(minus_s_g2.1)
-            .push(rd_ptr + 0x120)
-            .mstore()
-            .push(minus_s_g2.2)
-            .push(rd_ptr + 0x140)
-            .mstore()
-            .push(minus_s_g2.3)
-            .push(rd_ptr + 0x160)
-            .mstore();
+        let minus_s_g2_0 = hex_encode_u256(&minus_s_g2.0);
+        let minus_s_g2_0_ptr = rd_ptr + 0x100;
+        let minus_s_g2_1 = hex_encode_u256(&minus_s_g2.1);
+        let minus_s_g2_1_ptr = rd_ptr + 0x120;
+        let minus_s_g2_2 = hex_encode_u256(&minus_s_g2.2);
+        let minus_s_g2_2_ptr = rd_ptr + 0x140;
+        let minus_s_g2_3 = hex_encode_u256(&minus_s_g2.3);
+        let minus_s_g2_3_ptr = rd_ptr + 0x160;
+        let code = format!(
+            "mstore({minus_s_g2_0_ptr:#x}, {minus_s_g2_0})
+            mstore({minus_s_g2_1_ptr:#x}, {minus_s_g2_1})
+            mstore({minus_s_g2_2_ptr:#x}, {minus_s_g2_2})
+            mstore({minus_s_g2_3_ptr:#x}, {minus_s_g2_3})"
+        );
+        self.code.borrow_mut().runtime_append(code);
         self.staticcall(Precompiled::Bn254Pairing, rd_ptr, rd_ptr);
-        self.code.borrow_mut().push(rd_ptr).mload().and();
+        let code = format!("success := and(eq(mload({rd_ptr:#x}), 1), success)");
+        self.code.borrow_mut().runtime_append(code);
     }
 
     fn add(self: &Rc<Self>, lhs: &Scalar, rhs: &Scalar) -> Scalar {
@@ -525,22 +481,11 @@ impl EvmLoader {
         self.gas_metering_ids
             .borrow_mut()
             .push(identifier.to_string());
-        self.code.borrow_mut().gas().swap(1);
+        let code = format!("let {identifier} := gas()");
+        self.code.borrow_mut().runtime_append(code);
     }
 
-    fn end_gas_metering(self: &Rc<Self>) {
-        self.code
-            .borrow_mut()
-            .swap(1)
-            .push(9)
-            .gas()
-            .swap(2)
-            .sub()
-            .sub()
-            .push(0)
-            .push(0)
-            .log1();
-    }
+    fn end_gas_metering(self: &Rc<Self>) {}
 
     pub fn print_gas_metering(self: &Rc<Self>, costs: Vec<u64>) {
         for (identifier, cost) in self.gas_metering_ids.borrow().iter().zip(costs) {
@@ -745,7 +690,7 @@ impl PartialEq for Scalar {
 impl<F: PrimeField<Repr = [u8; 0x20]>> LoadedScalar<F> for Scalar {
     type Loader = Rc<EvmLoader>;
 
-    fn loader(&self) -> &Rc<EvmLoader> {
+    fn loader(&self) -> &Self::Loader {
         &self.loader
     }
 }
@@ -753,7 +698,7 @@ impl<F: PrimeField<Repr = [u8; 0x20]>> LoadedScalar<F> for Scalar {
 impl<C> EcPointLoader<C> for Rc<EvmLoader>
 where
     C: CurveAffine,
-    C::ScalarExt: PrimeField<Repr = [u8; 0x20]>,
+    C::Scalar: PrimeField<Repr = [u8; 0x20]>,
 {
     type LoadedEcPoint = EcPoint;
 
@@ -802,48 +747,39 @@ impl<F: PrimeField<Repr = [u8; 0x20]>> ScalarLoader<F> for Rc<EvmLoader> {
         let push_addend = |(coeff, value): &(F, &Scalar)| {
             assert_ne!(*coeff, F::zero());
             match (*coeff == F::one(), &value.value) {
-                (true, _) => {
-                    self.push(value);
-                }
-                (false, Value::Constant(value)) => {
-                    self.push(&self.scalar(Value::Constant(fe_to_u256(
-                        *coeff * u256_to_fe::<F>(*value),
-                    ))));
-                }
+                (true, _) => self.push(value),
+                (false, Value::Constant(value)) => self.push(&self.scalar(Value::Constant(
+                    fe_to_u256(*coeff * u256_to_fe::<F>(*value)),
+                ))),
                 (false, _) => {
-                    self.code.borrow_mut().push(self.scalar_modulus);
-                    self.push(&self.scalar(Value::Constant(fe_to_u256(*coeff))));
-                    self.push(value);
-                    self.code.borrow_mut().mulmod();
+                    let value = self.push(value);
+                    let coeff = self.push(&self.scalar(Value::Constant(fe_to_u256(*coeff))));
+                    format!("mulmod({value}, {coeff}, f_q)")
                 }
             }
         };
 
         let mut values = values.iter();
-        if constant == F::zero() {
-            push_addend(values.next().unwrap());
+        let initial_value = if constant == F::zero() {
+            push_addend(values.next().unwrap())
         } else {
-            self.push(&self.scalar(Value::Constant(fe_to_u256(constant))));
-        }
+            self.push(&self.scalar(Value::Constant(fe_to_u256(constant))))
+        };
 
-        let chunk_size = 16 - self.code.borrow().stack_len();
-        for values in &values.chunks(chunk_size) {
-            let values = values.into_iter().collect_vec();
-
-            self.code.borrow_mut().push(self.scalar_modulus);
-            for _ in 1..chunk_size.min(values.len()) {
-                self.code.borrow_mut().dup(0);
-            }
-            self.code.borrow_mut().swap(chunk_size.min(values.len()));
-
-            for value in values {
-                push_addend(value);
-                self.code.borrow_mut().addmod();
-            }
+        let mut code = format!("let result := {initial_value}\n");
+        for value in values {
+            let v = push_addend(value);
+            let addend = format!("result := addmod({v}, result, f_q)\n");
+            code.push_str(addend.as_str());
         }
 
         let ptr = self.allocate(0x20);
-        self.code.borrow_mut().push(ptr).mstore();
+        code.push_str(format!("mstore({ptr}, result)").as_str());
+        self.code.borrow_mut().runtime_append(format!(
+            "{{
+            {code}
+        }}"
+        ));
 
         self.scalar(Value::Memory(ptr))
     }
@@ -863,63 +799,64 @@ impl<F: PrimeField<Repr = [u8; 0x20]>> ScalarLoader<F> for Rc<EvmLoader> {
                 (_, Value::Constant(lhs), Value::Constant(rhs)) => {
                     self.push(&self.scalar(Value::Constant(fe_to_u256(
                         *coeff * u256_to_fe::<F>(*lhs) * u256_to_fe::<F>(*rhs),
-                    ))));
+                    ))))
                 }
                 (_, value @ Value::Memory(_), Value::Constant(constant))
                 | (_, Value::Constant(constant), value @ Value::Memory(_)) => {
-                    self.code.borrow_mut().push(self.scalar_modulus);
-                    self.push(&self.scalar(Value::Constant(fe_to_u256(
+                    let v1 = self.push(&self.scalar(value.clone()));
+                    let v2 = self.push(&self.scalar(Value::Constant(fe_to_u256(
                         *coeff * u256_to_fe::<F>(*constant),
                     ))));
-                    self.push(&self.scalar(value.clone()));
-                    self.code.borrow_mut().mulmod();
+                    format!("mulmod({v1}, {v2}, f_q)")
                 }
                 (true, _, _) => {
-                    self.code.borrow_mut().push(self.scalar_modulus);
-                    self.push(lhs);
-                    self.push(rhs);
-                    self.code.borrow_mut().mulmod();
+                    let rhs = self.push(rhs);
+                    let lhs = self.push(lhs);
+                    format!("mulmod({rhs}, {lhs}, f_q)")
                 }
                 (false, _, _) => {
-                    self.code.borrow_mut().push(self.scalar_modulus).dup(0);
-                    self.push(&self.scalar(Value::Constant(fe_to_u256(*coeff))));
-                    self.push(lhs);
-                    self.code.borrow_mut().mulmod();
-                    self.push(rhs);
-                    self.code.borrow_mut().mulmod();
+                    let rhs = self.push(rhs);
+                    let lhs = self.push(lhs);
+                    let value = self.push(&self.scalar(Value::Constant(fe_to_u256(*coeff))));
+                    format!("mulmod({rhs}, mulmod({lhs}, {value}, f_q), f_q)")
                 }
             }
         };
 
         let mut values = values.iter();
-        if constant == F::zero() {
-            push_addend(values.next().unwrap());
+        let initial_value = if constant == F::zero() {
+            push_addend(values.next().unwrap())
         } else {
-            self.push(&self.scalar(Value::Constant(fe_to_u256(constant))));
-        }
+            self.push(&self.scalar(Value::Constant(fe_to_u256(constant))))
+        };
 
-        let chunk_size = 16 - self.code.borrow().stack_len();
-        for values in &values.chunks(chunk_size) {
-            let values = values.into_iter().collect_vec();
-
-            self.code.borrow_mut().push(self.scalar_modulus);
-            for _ in 1..chunk_size.min(values.len()) {
-                self.code.borrow_mut().dup(0);
-            }
-            self.code.borrow_mut().swap(chunk_size.min(values.len()));
-
-            for value in values {
-                push_addend(value);
-                self.code.borrow_mut().addmod();
-            }
+        let mut code = format!("let result := {initial_value}\n");
+        for value in values {
+            let v = push_addend(value);
+            let addend = format!("result := addmod({v}, result, f_q)\n");
+            code.push_str(addend.as_str());
         }
 
         let ptr = self.allocate(0x20);
-        self.code.borrow_mut().push(ptr).mstore();
+        code.push_str(format!("mstore({ptr}, result)").as_str());
+        self.code.borrow_mut().runtime_append(format!(
+            "{{
+            {code}
+        }}"
+        ));
 
         self.scalar(Value::Memory(ptr))
     }
 
+    // batch_invert algorithm
+    // n := values.len() - 1
+    // input : values[0], ..., values[n]
+    // output : values[0]^{-1}, ..., values[n]^{-1}
+    // 1. products[i] <- values[0] * ... * values[i], i = 1, ..., n
+    // 2. inv <- (products[n])^{-1}
+    // 3. v_n <- values[n]
+    // 4. values[n] <- products[n - 1] * inv (values[n]^{-1})
+    // 5. inv <- v_n * inv
     fn batch_invert<'a>(values: impl IntoIterator<Item = &'a mut Scalar>) {
         let values = values.into_iter().collect_vec();
         let loader = &values.first().unwrap().loader;
@@ -931,29 +868,35 @@ impl<F: PrimeField<Repr = [u8; 0x20]>> ScalarLoader<F> for Rc<EvmLoader> {
             )
             .collect_vec();
 
-        loader.code.borrow_mut().push(loader.scalar_modulus);
-        for _ in 2..values.len() {
-            loader.code.borrow_mut().dup(0);
+        let initial_value = loader.push(products.first().unwrap());
+        let mut code = format!("let prod := {initial_value}\n");
+        for (_, (value, product)) in values.iter().zip(products.iter()).skip(1).enumerate() {
+            let v = loader.push(value);
+            let ptr = product.ptr();
+            code.push_str(
+                format!(
+                    "
+                prod := mulmod({v}, prod, f_q)
+                mstore({ptr:#x}, prod)
+            "
+                )
+                .as_str(),
+            );
         }
+        loader.code.borrow_mut().runtime_append(format!(
+            "{{
+            {code}
+        }}"
+        ));
 
-        loader.push(products.first().unwrap());
-        for (idx, (value, product)) in values.iter().zip(products.iter()).skip(1).enumerate() {
-            loader.push(value);
-            loader.code.borrow_mut().mulmod();
-            if idx < values.len() - 2 {
-                loader.code.borrow_mut().dup(0);
-            }
-            loader.code.borrow_mut().push(product.ptr()).mstore();
-        }
+        let inv = loader.push(&loader.invert(products.last().unwrap()));
 
-        let inv = loader.invert(products.last().unwrap());
-
-        loader.code.borrow_mut().push(loader.scalar_modulus);
-        for _ in 2..values.len() {
-            loader.code.borrow_mut().dup(0);
-        }
-
-        loader.push(&inv);
+        let mut code = format!(
+            "
+            let inv := {inv}
+            let v
+        "
+        );
         for (value, product) in values.iter().rev().zip(
             products
                 .iter()
@@ -963,22 +906,29 @@ impl<F: PrimeField<Repr = [u8; 0x20]>> ScalarLoader<F> for Rc<EvmLoader> {
                 .chain(iter::once(None)),
         ) {
             if let Some(product) = product {
-                loader.push(value);
-                loader
-                    .code
-                    .borrow_mut()
-                    .dup(2)
-                    .dup(2)
-                    .push(product.ptr())
-                    .mload()
-                    .mulmod()
-                    .push(value.ptr())
-                    .mstore()
-                    .mulmod();
+                let val_ptr = value.ptr();
+                let prod_ptr = product.ptr();
+                let v = loader.push(value);
+                code.push_str(
+                    format!(
+                        "
+                    v := {v}
+                    mstore({val_ptr}, mulmod(mload({prod_ptr:#x}), inv, f_q))
+                    inv := mulmod(v, inv, f_q)
+                "
+                    )
+                    .as_str(),
+                );
             } else {
-                loader.code.borrow_mut().push(value.ptr()).mstore();
+                let ptr = value.ptr();
+                code.push_str(format!("mstore({ptr:#x}, inv)\n").as_str());
             }
         }
+        loader.code.borrow_mut().runtime_append(format!(
+            "{{
+            {code}
+        }}"
+        ));
     }
 }
 

--- a/src/loader/evm/util.rs
+++ b/src/loader/evm/util.rs
@@ -3,7 +3,11 @@ use crate::{
     util::{arithmetic::PrimeField, Itertools},
 };
 use ethereum_types::U256;
-use std::iter;
+use std::{
+    io::Write,
+    iter,
+    process::{Command, Stdio},
+};
 
 pub(crate) mod executor;
 
@@ -93,4 +97,38 @@ pub fn estimate_gas(cost: Cost) -> usize {
     let ec_operation_cost = 113100 + (cost.num_msm - 2) * 6350;
 
     intrinsic_cost + calldata_cost + ec_operation_cost
+}
+
+pub fn compile_yul(code: &str) -> Vec<u8> {
+    let mut cmd = Command::new("solc")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .arg("--bin")
+        .arg("--yul")
+        .arg("-")
+        .spawn()
+        .unwrap();
+    cmd.stdin
+        .take()
+        .unwrap()
+        .write_all(code.as_bytes())
+        .unwrap();
+    let output = cmd.wait_with_output().unwrap().stdout;
+    let binary = *split_by_ascii_whitespace(&output).last().unwrap();
+    hex::decode(binary).unwrap()
+}
+
+fn split_by_ascii_whitespace(bytes: &[u8]) -> Vec<&[u8]> {
+    let mut split = Vec::new();
+    let mut start = None;
+    for (idx, byte) in bytes.iter().enumerate() {
+        if byte.is_ascii_whitespace() {
+            if let Some(start) = start.take() {
+                split.push(&bytes[start..idx]);
+            }
+        } else if start.is_none() {
+            start = Some(idx);
+        }
+    }
+    split
 }

--- a/src/pcs/kzg/decider.rs
+++ b/src/pcs/kzg/decider.rs
@@ -132,14 +132,8 @@ mod evm {
 
                 let hash_ptr = loader.keccak256(lhs[0].ptr(), lhs.len() * 0x80);
                 let challenge_ptr = loader.allocate(0x20);
-                loader
-                    .code_mut()
-                    .push(loader.scalar_modulus())
-                    .push(hash_ptr)
-                    .mload()
-                    .r#mod()
-                    .push(challenge_ptr)
-                    .mstore();
+                let code = format!("mstore({challenge_ptr}, mod(mload({hash_ptr}), f_q))");
+                loader.code_mut().runtime_append(code);
                 let challenge = loader.scalar(Value::Memory(challenge_ptr));
 
                 let powers_of_challenge = LoadedScalar::<M::Scalar>::powers(&challenge, lhs.len());

--- a/src/system/halo2/test/kzg/evm.rs
+++ b/src/system/halo2/test/kzg/evm.rs
@@ -49,7 +49,8 @@ macro_rules! halo2_kzg_evm_verify {
                 .unwrap();
             <$plonk_verifier>::verify(&svk, &dk, &protocol, &instances, &proof).unwrap();
 
-            loader.runtime_code()
+            let code = loader.yul_code();
+            loader.compile(&code)
         };
 
         let (accept, total_cost, costs) =

--- a/src/system/halo2/test/kzg/evm.rs
+++ b/src/system/halo2/test/kzg/evm.rs
@@ -24,7 +24,7 @@ macro_rules! halo2_kzg_evm_verify {
         use halo2_proofs::poly::commitment::ParamsProver;
         use std::rc::Rc;
         use $crate::{
-            loader::evm::{encode_calldata, execute, EvmLoader},
+            loader::evm::{compile_yul, encode_calldata, execute, EvmLoader},
             system::halo2::{
                 test::kzg::{BITS, LIMBS},
                 transcript::evm::EvmTranscript,
@@ -34,7 +34,7 @@ macro_rules! halo2_kzg_evm_verify {
         };
 
         let loader = EvmLoader::new::<Fq, Fr>();
-        let runtime_code = {
+        let deployment_code = {
             let svk = $params.get_g()[0].into();
             let dk = ($params.g2(), $params.s_g2()).into();
             let protocol = $protocol.loaded(&loader);
@@ -49,12 +49,11 @@ macro_rules! halo2_kzg_evm_verify {
                 .unwrap();
             <$plonk_verifier>::verify(&svk, &dk, &protocol, &instances, &proof).unwrap();
 
-            let code = loader.yul_code();
-            loader.compile(&code)
+            compile_yul(&loader.yul_code())
         };
 
         let (accept, total_cost, costs) =
-            execute(runtime_code, encode_calldata($instances, &$proof));
+            execute(deployment_code, encode_calldata($instances, &$proof));
 
         loader.print_gas_metering(costs);
         println!("Total gas cost: {}", total_cost);


### PR DESCRIPTION
I worked on updating `EvmLoader` to generate Yul code instead of EVM bytecode. Also, I updated `kzg::decider::Decider` and `transcript::evm::EvmTranscript` to generate Yul.

The motivation of my work is to make EVM full plonk verifier to be auditable and more human readable. It's my first time to contribute to this project, so it will be really thankful to give me many comments if something is wrong.