### PR TITLE
Update accumulator.rs

### DIFF
--- a/snark-verifier/src/pcs/kzg/accumulator.rs
+++ b/snark-verifier/src/pcs/kzg/accumulator.rs
@@ -27,8 +27,8 @@ where
 
 /// `AccumulatorEncoding` that encodes `Accumulator` into limbs.
 ///
-/// Since in circuit everything are in scalar field, but `Accumulator` might contain base field elements, so we split them into limbs.
-/// The const generic `LIMBS` and `BITS` respectively represents how many limbs
+/// Since in circuit everything is in scalar field, but `Accumulator` might contain base field elements, so we split them into limbs.
+/// The const generic `LIMBS` and `BITS` respectively represent how many limbs
 /// a base field element are split into and how many bits each limbs could have.
 #[derive(Clone, Debug)]
 pub struct LimbsEncoding<const LIMBS: usize, const BITS: usize>;
@@ -166,7 +166,7 @@ mod halo2 {
         x.zip(y).map(|(x, y)| C::from_xy(x, y).unwrap())
     }
 
-    /// Instructions to encode/decode a elliptic curve point into/from limbs.
+    /// Instructions to encode/decode an elliptic curve point into/from limbs.
     pub trait LimbsEncodingInstructions<'a, C: CurveAffine, const LIMBS: usize, const BITS: usize>:
         EccInstructions<'a, C>
     {


### PR DESCRIPTION

## Changes

### 1. snark-verifier/src/pcs/kzg/accumulator.rs
- Old: "Since in circuit everything are in scalar field..."
- New: "Since in circuit everything is in scalar field..."
- Old: "The const generic `LIMBS` and `BITS` respectively represents..."
- New: "The const generic `LIMBS` and `BITS` respectively represent..."

Reason: Fixed subject-verb agreement for better grammatical accuracy.

### 2. snark-verifier/src/system/halo2/transcript/halo2.rs
- Old: "Instructions to encode/decode a elliptic curve point..."
- New: "Instructions to encode/decode an elliptic curve point..."

Reason: Fixed incorrect article usage ("a" to "an" before word starting with vowel sound).
