### PR TITLE
Fix typos and grammatical errors in documentation and code comments

### DIFF
--- a/snark-verifier/src/loader/halo2/shim.rs
+++ b/snark-verifier/src/loader/halo2/shim.rs
@@ -110,14 +110,14 @@ pub trait EccInstructions<'a, C: CurveAffine>: Clone + Debug {
     /// Returns reference of [`EccInstructions::ScalarChip`].
     fn scalar_chip(&self) -> &Self::ScalarChip;
 
-    /// Assign a elliptic curve point constant.
+    /// Assign an elliptic curve point constant.
     fn assign_constant(
         &self,
         ctx: &mut Self::Context,
         ec_point: C,
     ) -> Result<Self::AssignedEcPoint, Error>;
 
-    /// Assign a elliptic curve point witness.
+    /// Assign an elliptic curve point witness.
     fn assign_point(
         &self,
         ctx: &mut Self::Context,

--- a/snark-verifier/src/pcs/kzg/accumulator.rs
+++ b/snark-verifier/src/pcs/kzg/accumulator.rs
@@ -166,7 +166,7 @@ mod halo2 {
         x.zip(y).map(|(x, y)| C::from_xy(x, y).unwrap())
     }
 
-    /// Instructions to encode/decode a elliptic curve point into/from limbs.
+    /// Instructions to encode/decode an elliptic curve point into/from limbs.
     pub trait LimbsEncodingInstructions<'a, C: CurveAffine, const LIMBS: usize, const BITS: usize>:
         EccInstructions<'a, C>
     {

--- a/snark-verifier/src/util/poly.rs
+++ b/snark-verifier/src/util/poly.rs
@@ -15,7 +15,7 @@ use std::{
 pub struct Polynomial<F>(Vec<F>);
 
 impl<F> Polynomial<F> {
-    /// Initialize an univariate polynomial.
+    /// Initialize a univariate polynomial.
     pub fn new(inner: Vec<F>) -> Self {
         Self(inner)
     }

--- a/snark-verifier/src/util/transcript.rs
+++ b/snark-verifier/src/util/transcript.rs
@@ -57,6 +57,6 @@ pub trait TranscriptWrite<C: CurveAffine>: Transcript<C, NativeLoader> {
     /// Write a scalar.
     fn write_scalar(&mut self, scalar: C::Scalar) -> Result<(), Error>;
 
-    /// Write a elliptic curve point.
+    /// Write an elliptic curve point.
     fn write_ec_point(&mut self, ec_point: C) -> Result<(), Error>;
 }

--- a/snark-verifier/src/util/transcript.rs
+++ b/snark-verifier/src/util/transcript.rs
@@ -43,7 +43,7 @@ where
         (0..n).map(|_| self.read_scalar()).collect()
     }
 
-    /// Read a elliptic curve point.
+    /// Read an elliptic curve point.
     fn read_ec_point(&mut self) -> Result<L::LoadedEcPoint, Error>;
 
     /// Read `n` elliptic curve point.


### PR DESCRIPTION
This pull request addresses grammatical issues in the code and comments, specifically correcting the usage of articles "a" and "an" based on the starting sounds of the following words. 
The changes improve the readability and professionalism of the codebase.
