### PR TITLE
Fix typo in AccumulationDecider trait documentation

### DIFF
--- a/snark-verifier/src/pcs.rs
+++ b/snark-verifier/src/pcs.rs
@@ -1,4 +1,4 @@
-//! Verfieirs for polynomial commitment schemes.
+//! Verifiers for polynomial commitment schemes.
 
 use crate::{
     loader::{native::NativeLoader, Loader},


### PR DESCRIPTION
Corrects a grammatical error in the documentation comment for the DecidingKey type in the AccumulationDecider trait. Changed "The key for decider for perform" to "The key for decider to perform".